### PR TITLE
feat: add Your stacks header and tabs

### DIFF
--- a/packages/app/app/layout.tsx
+++ b/packages/app/app/layout.tsx
@@ -1,3 +1,4 @@
+import { PropsWithChildren } from "react";
 import "../styles/global.css";
 import Navbar from "@/components/navbar/Navbar";
 
@@ -7,11 +8,7 @@ export const metadata = {
     "Stackly is a simple, non-custodial tool that uses the CoW protocol to place recurring swaps based on DCA..",
 };
 
-interface RootLayoutProps {
-  children: React.ReactNode;
-}
-
-export default function RootLayout({ children }: RootLayoutProps) {
+export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en">
       <body className="max-w-screen-xl px-4 mx-auto font-sans bg-surface-25">

--- a/packages/app/app/stacks/empty-state.tsx
+++ b/packages/app/app/stacks/empty-state.tsx
@@ -2,7 +2,7 @@ import StackOfCoinsImage from "@/public/assets/images/empty-state-stacks-coins.s
 import { ButtonLink, HeadingText } from "@/ui";
 
 export const EmptyState = () => (
-  <div className="max-w-xl pt-32 mx-auto space-y-8">
+  <div className="max-w-xl mx-auto space-y-8">
     <div className="flex flex-col items-center space-y-6 md:space-y-8">
       <StackOfCoinsImage />
       <div className="space-y-3 text-center">

--- a/packages/app/app/stacks/layout.tsx
+++ b/packages/app/app/stacks/layout.tsx
@@ -1,0 +1,11 @@
+export const metadata = {
+  title: "Your stacks | Stackly",
+};
+
+interface YourStacksLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function YourStacksLayout({ children }: YourStacksLayoutProps) {
+  return <div className="max-w-5xl pt-24 mx-auto">{children}</div>;
+}

--- a/packages/app/app/stacks/layout.tsx
+++ b/packages/app/app/stacks/layout.tsx
@@ -1,11 +1,9 @@
+import { PropsWithChildren } from "react";
+
 export const metadata = {
   title: "Your stacks | Stackly",
 };
 
-interface YourStacksLayoutProps {
-  children: React.ReactNode;
-}
-
-export default function YourStacksLayout({ children }: YourStacksLayoutProps) {
-  return <div className="max-w-5xl pt-24 mx-auto">{children}</div>;
+export default function YourStacksLayout({ children }: PropsWithChildren) {
+  return <div className="max-w-5xl pt-12 mx-auto md:pt-24">{children}</div>;
 }

--- a/packages/app/app/stacks/page.tsx
+++ b/packages/app/app/stacks/page.tsx
@@ -1,11 +1,57 @@
 "use client";
 
+import { Tab } from "@headlessui/react";
 import { EmptyState } from "@/app/stacks/empty-state";
+import { ButtonLink, HeadingText } from "@/ui";
+import { StacksTable } from "@/app/stacks/table";
 
 export default function Page() {
+  const data = true;
+
+  if (!data) return <EmptyState />;
+
   return (
-    <div className="w-full max-w-screen-xl px-4 mx-auto">
-      <EmptyState />
+    <div className="space-y-8">
+      <div className="flex items-center justify-between">
+        <HeadingText size={3}>Your stacks</HeadingText>
+        <ButtonLink
+          iconLeft="plus"
+          href="/"
+          width="fit"
+          size="sm"
+          className="hidden sm:flex"
+        >
+          Create New Stack
+        </ButtonLink>
+      </div>
+      <div className="space-y-6">
+        <Tab.Group>
+          <Tab.List>
+            <div className="flex space-x-2">
+              <Tab
+                as="button"
+                className="px-3 py-1.5 font-semibold rounded-lg ui-selected:bg-surface-75 ui-not-selected:text-em-low outline-none active:ring-2 active:ring-gray-100"
+              >
+                Active Stacks
+              </Tab>
+              <Tab
+                as="button"
+                className="px-3 py-1.5 font-semibold rounded-lg ui-selected:bg-surface-75 ui-not-selected:text-em-low outline-none active:ring-2 active:ring-gray-100"
+              >
+                Completed stacks
+              </Tab>
+            </div>
+          </Tab.List>
+          <Tab.Panels>
+            <Tab.Panel>
+              <StacksTable text="active" />
+            </Tab.Panel>
+            <Tab.Panel>
+              <StacksTable text="Completed" />
+            </Tab.Panel>
+          </Tab.Panels>
+        </Tab.Group>
+      </div>
     </div>
   );
 }

--- a/packages/app/app/stacks/table.tsx
+++ b/packages/app/app/stacks/table.tsx
@@ -1,0 +1,5 @@
+export const StacksTable = ({ text }: { text: string }) => (
+  <div className="w-full bg-white h-96 rounded-3xl">
+    <p className="py-32 text-center text-em-low">{text} table</p>
+  </div>
+);

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -17,7 +17,7 @@ export const Stackbox = () => {
 
   return (
     <div>
-      <div className="max-w-lg mx-auto my-32 bg-white shadow-2xl rounded-2xl">
+      <div className="max-w-lg mx-auto my-24 bg-white shadow-2xl rounded-2xl">
         <div className="px-5 py-4 border shadow-lg border-surface-50 rounded-2xl">
           <div className="flex items-end justify-between pb-4 border-b border-surface-50">
             <div className="space-y-2">

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.7.14",
+    "@headlessui/tailwindcss": "^0.1.3",
     "class-variance-authority": "^0.6.0",
     "next": "^13.4.1",
     "react": "^18.2.0",

--- a/packages/app/tailwind.config.js
+++ b/packages/app/tailwind.config.js
@@ -89,5 +89,5 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [require("@headlessui/tailwindcss")],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,6 +1536,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@headlessui/tailwindcss@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "@headlessui/tailwindcss@npm:0.1.3"
+  peerDependencies:
+    tailwindcss: ^3.0
+  checksum: 65a2cfdf8560d83824fa8d350ea9799b95bc79aefa7c20b4be7c73cd285de8d3d652b26f2cfdb82d225d8d922e28ca898179bdaf6a0f7b88408e6ad831808959
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.8":
   version: 0.11.8
   resolution: "@humanwhocodes/config-array@npm:0.11.8"
@@ -2151,6 +2160,7 @@ __metadata:
   resolution: "app@workspace:packages/app"
   dependencies:
     "@headlessui/react": ^1.7.14
+    "@headlessui/tailwindcss": ^0.1.3
     "@svgr/webpack": ^8.0.1
     "@types/node": ^18.0.0
     "@types/react": ^18.2.5


### PR DESCRIPTION
## Summary
- add header with title and button
- add tabs with headless ui
- install @headlessui/tailwindcss plugin to be able to use "selected-ui:" helpers
- add layout page
- add mock stacks table

<img width="1918" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/97e5f789-15dc-4a1d-89df-6f2859751c13">
