### PR TITLE
Stk 29 create tokenicon component

### DIFF
--- a/packages/app/components/FromToStackTokenPair.tsx
+++ b/packages/app/components/FromToStackTokenPair.tsx
@@ -1,6 +1,7 @@
 import { Order, Token, totalFundsUsed } from "@/models/order";
 import { totalStacked } from "@/components/StacksTable";
 import { Icon, TitleText } from "@/ui";
+import { TokenIcon } from "@/components/TokenIcon";
 
 interface FromToStackTokenPairProps {
   order?: Order;
@@ -12,22 +13,27 @@ export const FromToStackTokenPair = ({
   fromToken,
   toToken,
   order,
-}: FromToStackTokenPairProps) => (
-  <div className="flex items-center space-x-4 rounded-3xl w-fit">
-    <div className="flex items-center space-x-2">
-      <div className="w-6 h-6 rounded-full bg-primary-100"></div>
-      <TitleText>
-        {order ? totalFundsUsed(order).toFixed(2) : fromToken?.symbol}
-      </TitleText>
+}: FromToStackTokenPairProps) => {
+  const token0 = order ? order?.sellToken : fromToken;
+  const token1 = order ? order?.buyToken : toToken;
+
+  return (
+    <div className="flex items-center space-x-4 rounded-3xl w-fit">
+      <div className="flex items-center space-x-2">
+        {token0 && <TokenIcon token={token0} size="sm" />}
+        <TitleText>
+          {order ? totalFundsUsed(order).toFixed(2) : fromToken?.symbol}
+        </TitleText>
+      </div>
+      <div className="p-1 rounded-xl md:rounded-2xl md:p-2 bg-surface-75">
+        <Icon size={20} className="rotate-180" name="arrow-left" />
+      </div>
+      <div className="flex items-center space-x-2">
+        {token1 && <TokenIcon token={token1} size="sm" />}
+        <TitleText>
+          {order ? totalStacked(order).toFixed(4) : toToken?.symbol}
+        </TitleText>
+      </div>
     </div>
-    <div className="p-1 rounded-xl md:rounded-2xl md:p-2 bg-surface-75">
-      <Icon size={20} className="rotate-180" name="arrow-left" />
-    </div>
-    <div className="flex items-center space-x-2">
-      <div className="w-6 h-6 rounded-full bg-primary-100"></div>
-      <TitleText>
-        {order ? totalStacked(order).toFixed(4) : toToken?.symbol}
-      </TitleText>
-    </div>
-  </div>
-);
+  );
+};

--- a/packages/app/components/StackedTokenLogoPair.tsx
+++ b/packages/app/components/StackedTokenLogoPair.tsx
@@ -1,12 +1,9 @@
+import { TokenIcon } from "@/components/TokenIcon";
 import { OrderProps } from "@/models/order";
 
 export const StackedTokenLogoPair = ({ order }: OrderProps) => (
   <div className="flex items-end">
-    <div className="flex items-center justify-center w-10 h-10 text-[10px] border-2 rounded-full border-primary-400 bg-primary-100">
-      {order.buyToken.symbol.substring(0, 4)}
-    </div>
-    <div className="flex items-center justify-center w-5 h-5 -ml-2 text-[8px]  border-primary-400 border rounded-full bg-primary-200">
-      {order.sellToken.symbol.substring(2, 5)}
-    </div>
+    <TokenIcon token={order.buyToken} size="lg" />
+    <TokenIcon token={order.sellToken} size="xs" className="-ml-2" />
   </div>
 );

--- a/packages/app/components/StacksTable.tsx
+++ b/packages/app/components/StacksTable.tsx
@@ -121,7 +121,7 @@ export const StacksTable = ({ orders }: { orders: Order[] }) => {
         <TableBody>
           {orders.map((order) => (
             <TableRow key={order.id}>
-              <TableCell className="flex items-center font-medium">
+              <TableCell className="flex items-center font-medium w-max">
                 <StackedTokenLogoPair order={order} />
                 <div className="ml-3 space-y-0.5">
                   <BodyText weight="bold">

--- a/packages/app/components/TokenIcon.tsx
+++ b/packages/app/components/TokenIcon.tsx
@@ -1,0 +1,107 @@
+import { isAddress } from "viem";
+import { cva } from "class-variance-authority";
+import { Token } from "@/models/order";
+import Image from "next/image";
+import { useCallback, useEffect, useState } from "react";
+import { useNetwork } from "wagmi";
+import { twMerge } from "tailwind-merge";
+
+interface TokenIconProps {
+  token: Token;
+  className?: string;
+  size?: "lg" | "md" | "sm" | "xs";
+}
+
+const TOKEN_LIST_BY_CHAIN_URL: { [chainId: number]: string } = {
+  1: "https://tokens.1inch.eth.link/",
+  100: "https://tokens.honeyswap.org/",
+};
+
+type TokenFromList = {
+  address: string;
+  chainId: number;
+  decimals: number;
+  logoURI: string;
+  name: string;
+  symbol: string;
+};
+
+const GNOSIS_CHAIN_ID = 100;
+
+export const TokenIcon = ({ token, className, size }: TokenIconProps) => {
+  const { chain } = useNetwork();
+  const [tokensList, setTokensList] = useState<TokenFromList[]>([]);
+
+  const setupTokenList = useCallback(async () => {
+    async function getTokensListData() {
+      const res = await fetch(
+        chain
+          ? TOKEN_LIST_BY_CHAIN_URL[chain.id]
+          : TOKEN_LIST_BY_CHAIN_URL[GNOSIS_CHAIN_ID]
+      );
+      if (!res.ok) {
+        // This will activate the closest `error.js` Error Boundary
+        throw new Error("Failed to fetch data");
+      }
+      return res.json();
+    }
+    const data = await getTokensListData();
+    setTokensList(data.tokens);
+  }, [chain]);
+
+  function getToken(tokenAddress: string) {
+    return tokensList.find(
+      (element) => element.address.toUpperCase() === tokenAddress.toUpperCase()
+    );
+  }
+
+  function getTokenLogoURL() {
+    return getToken(token.id)?.logoURI ?? "";
+  }
+
+  useEffect(() => {
+    setupTokenList();
+  }, [setupTokenList]);
+
+  if (!token.id || !isAddress(token.id) || !getToken(token.id))
+    return <DefaultTokenIcon token={token} className={className} size={size} />;
+
+  return (
+    <Image
+      src={getTokenLogoURL()}
+      className={tokenIconStyles({ size, className })}
+      alt={token.name}
+      width={54}
+      height={54}
+    />
+  );
+};
+
+const DefaultTokenIcon = ({ token, size, className }: TokenIconProps) => (
+  <div
+    className={twMerge(
+      tokenIconStyles({ size }),
+      className,
+      "bg-primary-100 border border-primary-200 break-all"
+    )}
+  >
+    {token.symbol}
+  </div>
+);
+
+export const tokenIconStyles = cva(
+  ["flex items-center justify-center", "rounded-full bg-surface-50"],
+  {
+    variants: {
+      size: {
+        lg: ["w-10 h-10 text-[7px]"],
+        md: ["w-8 h-8 text-[6px]"],
+        sm: ["w-6 h-6 text-[5px]"],
+        xs: ["w-5 h-5 text-[4px]"],
+      },
+    },
+    defaultVariants: {
+      size: "md",
+    },
+  }
+);

--- a/packages/app/components/stack-modal/StackProgress.tsx
+++ b/packages/app/components/stack-modal/StackProgress.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/models/order";
 import { OrdersProgressBar } from "@/components/OrdersProgressBar";
 import { BodyText } from "@/ui";
+import { TokenIcon } from "@/components/TokenIcon";
 
 export const StackProgress = ({ order }: OrderProps) => (
   <div className="mt-3 space-y-3">
@@ -19,7 +20,7 @@ export const StackProgress = ({ order }: OrderProps) => (
             <span className="text-xs">of</span> {fundsAmountWithToken(order)}
           </span>
         </BodyText>
-        <div className="w-4 h-4 rounded-full bg-primary-100"></div>
+        <TokenIcon size="xs" token={order.sellToken} />
       </div>
     </div>
     <OrdersProgressBar order={order} />

--- a/packages/app/components/stackbox/ConfirmStackModal.tsx
+++ b/packages/app/components/stackbox/ConfirmStackModal.tsx
@@ -22,14 +22,14 @@ export const ConfirmStackModal = ({ isOpen, closeAction }: ModalBaseProps) => {
   }
 
   const fromToken = {
-    id: "absadcas",
+    id: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83",
     symbol: "USDC",
     decimals: 18,
     name: "usdc",
   };
 
   const toToken = {
-    id: "0x213edas",
+    id: "0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1",
     symbol: "WETH",
     decimals: 18,
     name: "wrapped eth",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -26,14 +26,14 @@
   },
   "devDependencies": {
     "@svgr/webpack": "^8.0.1",
-    "@types/node": "^18.0.0",
-    "@types/react": "^18.2.5",
+    "@types/node": "20.3.1",
+    "@types/react": "18.2.13",
     "autoprefixer": "^10.4.14",
     "eslint": "^8.11.0",
     "eslint-config-next": "canary",
     "postcss": "^8.4.23",
     "sharp": "^0.32.1",
     "tailwindcss": "^3.3.2",
-    "typescript": "^5.0.4"
+    "typescript": "5.1.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2990,17 +2990,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:20.3.1":
+  version: 20.3.1
+  resolution: "@types/node@npm:20.3.1"
+  checksum: 63a393ab6d947be17320817b35d7277ef03728e231558166ed07ee30b09fd7c08861be4d746f10fdc63ca7912e8cd023939d4eab887ff6580ff704ff24ed810c
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^12.12.54":
   version: 12.20.55
   resolution: "@types/node@npm:12.20.55"
   checksum: e4f86785f4092706e0d3b0edff8dca5a13b45627e4b36700acd8dfe6ad53db71928c8dee914d4276c7fd3b6ccd829aa919811c9eb708a2c8e4c6eb3701178c37
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^18.0.0":
-  version: 18.16.16
-  resolution: "@types/node@npm:18.16.16"
-  checksum: 0efad726dd1e0bef71c392c708fc5d78c5b39c46b0ac5186fee74de4ccb1b2e847b3fa468da67d62812f56569da721b15bf31bdc795e6c69b56c73a45079ed2d
   languageName: node
   linkType: hard
 
@@ -3011,14 +3011,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^18.2.5":
-  version: 18.2.8
-  resolution: "@types/react@npm:18.2.8"
+"@types/react@npm:18.2.13":
+  version: 18.2.13
+  resolution: "@types/react@npm:18.2.13"
   dependencies:
     "@types/prop-types": "*"
     "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: 351fe2450d30bff2ceb6aa84788e948317555e5ea22cb44f6778e08c977aab1878a0119bd94bc3d1bec5f5af4a75ffaa2ce111df5cd9d4ce26bfd719e4d971c2
+  checksum: f7c15f19c164a29262993ea2aae2085fa38cddd9b8359fd8fefabfced91010b515a3abe2042b2b7f2f86e6b38a25b191415aa9313a9027175e3a000883c858cc
   languageName: node
   linkType: hard
 
@@ -3751,8 +3751,8 @@ __metadata:
     "@headlessui/react": ^1.7.14
     "@headlessui/tailwindcss": ^0.1.3
     "@svgr/webpack": ^8.0.1
-    "@types/node": ^18.0.0
-    "@types/react": ^18.2.5
+    "@types/node": 20.3.1
+    "@types/react": 18.2.13
     autoprefixer: ^10.4.14
     class-variance-authority: ^0.6.0
     connectkit: ^1.4.0
@@ -3765,7 +3765,7 @@ __metadata:
     sharp: ^0.32.1
     tailwind-merge: ^1.12.0
     tailwindcss: ^3.3.2
-    typescript: ^5.0.4
+    typescript: 5.1.3
     viem: ^1.0.2
     wagmi: ^1.1.1
   languageName: unknown
@@ -9391,7 +9391,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.0.4":
+"typescript@npm:5.1.3":
   version: 5.1.3
   resolution: "typescript@npm:5.1.3"
   bin:
@@ -9401,7 +9401,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5.0.4#~builtin<compat/typescript>":
+"typescript@patch:typescript@5.1.3#~builtin<compat/typescript>":
   version: 5.1.3
   resolution: "typescript@patch:typescript@npm%3A5.1.3#~builtin<compat/typescript>::version=5.1.3&hash=77c9e2"
   bin:


### PR DESCRIPTION
# Description
This PR adds `TokenIcon` component which fetches token image from a token list based on address.
If it does not have it shows a default component with token symbol.

<img width="604" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/e65448b7-5665-4f7f-ab64-06764d93edb5">



### Summary
Add `TokenIcon` component
  - Gets token list based on chain
    - uses honeyswap list on gnosis
    - uses  1inch list on ethereum
    - Tested out with `coingecko` but assets are small and blury.
  - get image url for a given token address from the list
  - if does not have data for that token, shows a default component
- Updates types/react and typescript packages. 




