### PR TITLE
fix: condition got error when cowOrders was undefined

### DIFF
--- a/packages/app/models/stack-order/stack-order.ts
+++ b/packages/app/models/stack-order/stack-order.ts
@@ -1,14 +1,17 @@
 import { StackOrder } from "@/models/stack-order";
 import { convertedAmount } from "@/utils/numbers";
 
-export const totalStackOrdersDone = (order: StackOrder) =>
-  order.cowOrders.length;
+export const totalStackOrdersDone = (order: StackOrder) => {
+  if (!order?.cowOrders?.length) return 0;
+
+  return order.cowOrders.length;
+};
 
 export const calculateStackAveragePrice = (order: StackOrder) => {
   let totalExecutedBuyAmount = 0;
   let totalExecutedSellAmount = 0;
 
-  if (order.cowOrders.length === 0) return 0;
+  if (!order?.cowOrders?.length) return 0;
 
   order.cowOrders.forEach((cowOrder) => {
     if (cowOrder.executedBuyAmount === "0") return;


### PR DESCRIPTION
**Description**
Fix error when opening a modal with cowOrders undefined

**Summary**
- add it to calculateStackAveragePrice and totalStackOrdersDone

**Error**
<img width="906" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/fed05cc7-b87c-4467-967c-327fe7c1dbc8">
