### PR TITLE
fix: Progress bar should be based on cow orders and not on order slots

### DIFF
--- a/packages/app/components/OrdersProgressBar.tsx
+++ b/packages/app/components/OrdersProgressBar.tsx
@@ -1,16 +1,16 @@
-import { OrderProps, totalOrderSlotsDone } from "@/models/order";
+import { StackOrderProps, totalStackOrdersDone } from "@/models/stack-order";
 import React, { useRef, useEffect } from "react";
 
-export const OrdersProgressBar = ({ order }: OrderProps) => {
+export const OrdersProgressBar = ({ stackOrder }: StackOrderProps) => {
   const progressBarRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (progressBarRef.current) {
       const width =
-        (100 * totalOrderSlotsDone(order)) / order.orderSlots.length;
+        (100 * totalStackOrdersDone(stackOrder)) / stackOrder.orderSlots.length;
       progressBarRef.current.style.width = `${width}%`;
     }
-  }, [order]);
+  }, [stackOrder]);
 
   return (
     <div className="w-full h-2 rounded-lg bg-surface-75">

--- a/packages/app/components/OrdersProgressBar.tsx
+++ b/packages/app/components/OrdersProgressBar.tsx
@@ -1,4 +1,4 @@
-import { OrderProps, totalOrdersDone, totalOrders } from "@/models/order";
+import { OrderProps, totalOrderSlotsDone } from "@/models/order";
 import React, { useRef, useEffect } from "react";
 
 export const OrdersProgressBar = ({ order }: OrderProps) => {
@@ -6,7 +6,8 @@ export const OrdersProgressBar = ({ order }: OrderProps) => {
 
   useEffect(() => {
     if (progressBarRef.current) {
-      const width = (100 * totalOrdersDone(order)) / totalOrders(order);
+      const width =
+        (100 * totalOrderSlotsDone(order)) / order.orderSlots.length;
       progressBarRef.current.style.width = `${width}%`;
     }
   }, [order]);

--- a/packages/app/components/StacksTable.tsx
+++ b/packages/app/components/StacksTable.tsx
@@ -16,7 +16,7 @@ import { StackedTokenLogoPair, StackModal } from "@/components";
 import {
   fundsAmountWithToken,
   getOrderPairSymbols,
-  totalOrdersDone,
+  totalOrderSlotsDone,
 } from "@/models/order";
 import { formatTimestampToDateWithSuffix } from "@/utils/datetime";
 import {
@@ -132,7 +132,7 @@ const CellWrapper = ({ children }: PropsWithChildren) => (
 );
 
 const OrdersProgressText = ({ stackOrder }: StackOrderProps) =>
-  totalOrdersDone(stackOrder) === 0 ? (
+  totalOrderSlotsDone(stackOrder) === 0 ? (
     <BodyText className="text-primary-700">
       Starts on {formatTimestampToDateWithSuffix(stackOrder.orderSlots[0])}
     </BodyText>

--- a/packages/app/components/stack-modal/StackModal.tsx
+++ b/packages/app/components/stack-modal/StackModal.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { ReactNode, useState } from "react";
 
-import { getOrderPairSymbols, totalOrdersDone } from "@/models/order";
+import { getOrderPairSymbols, totalOrderSlotsDone } from "@/models/order";
 import {
   Modal,
   ModalFooter,
@@ -72,7 +72,7 @@ export const StackModal = ({
   const orderSlots = stackOrder.orderSlots;
   const firstSlot = orderSlots[0];
   const lastSlot = orderSlots[orderSlots.length - 1];
-  const nextSlot = orderSlots[totalOrdersDone(stackOrder)];
+  const nextSlot = orderSlots[totalOrderSlotsDone(stackOrder)];
 
   const remainingFunds =
     convertedAmount(stackOrder.amount, stackOrder.sellToken.decimals) -
@@ -83,7 +83,8 @@ export const StackModal = ({
     `remaining funds, ${remainingFunds} ${stackOrder.sellToken.symbol}`;
 
   const stackIsComplete =
-    totalOrdersDone(stackOrder) === orderSlots.length && remainingFunds === 0;
+    totalOrderSlotsDone(stackOrder) === orderSlots.length &&
+    remainingFunds === 0;
 
   const cancelStack = async () => {
     if (!signer) return;

--- a/packages/app/components/stack-modal/StackProgress.tsx
+++ b/packages/app/components/stack-modal/StackProgress.tsx
@@ -1,4 +1,4 @@
-import { fundsAmountWithToken, totalOrdersDone } from "@/models/order";
+import { fundsAmountWithToken, totalOrderSlotsDone } from "@/models/order";
 import { OrdersProgressBar } from "@/components/OrdersProgressBar";
 import { BodyText } from "@/ui";
 import { TokenIcon } from "@/components/TokenIcon";
@@ -30,7 +30,7 @@ export const StackProgress = ({ stackOrder }: StackOrderProps) => (
 );
 
 const OrdersExecuted = ({ stackOrder }: StackOrderProps) => {
-  if (!totalOrdersDone(stackOrder))
+  if (!totalOrderSlotsDone(stackOrder))
     return <BodyText className="text-em-low">No orders executed yet.</BodyText>;
 
   return (

--- a/packages/app/components/stack-modal/StackProgress.tsx
+++ b/packages/app/components/stack-modal/StackProgress.tsx
@@ -25,7 +25,7 @@ export const StackProgress = ({ stackOrder }: StackOrderProps) => (
         <TokenIcon size="xs" token={stackOrder.sellToken} />
       </div>
     </div>
-    <OrdersProgressBar order={stackOrder} />
+    <OrdersProgressBar stackOrder={stackOrder} />
   </div>
 );
 

--- a/packages/app/models/order/order.ts
+++ b/packages/app/models/order/order.ts
@@ -2,7 +2,7 @@ import { convertedAmount } from "@/utils/numbers";
 import { currentTimestampInSeconds } from "@/utils/datetime";
 import { Order } from "@stackly/sdk";
 
-export const totalOrdersDone = (order: Order) => {
+export const totalOrderSlotsDone = (order: Order) => {
   return order.orderSlots.reduce((count, orderTimestamp) => {
     if (Number(orderTimestamp) < currentTimestampInSeconds) return ++count;
     return count;
@@ -14,8 +14,6 @@ export const fundsAmount = (order: Order) =>
 
 export const fundsAmountWithToken = (order: Order) =>
   `${fundsAmount(order)} ${order.sellToken.symbol}`;
-
-export const totalOrders = (order: Order) => order.orderSlots.length;
 
 export const getOrderPairSymbols = (order: Order) =>
   `${order.buyToken.symbol}/${order.sellToken.symbol}`;


### PR DESCRIPTION
**Description**
Progress bar should be based on cow orders and not on order slots, this was causing a bug of showing progress without orders.


**Screenshot**
<img width="660" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/6064292a-b0b1-49f6-bf67-a3ff24e8c562">
