### PR TITLE
fix: changing network on mobile when menu is open

### DIFF
--- a/packages/app/components/SelectNetwork.tsx
+++ b/packages/app/components/SelectNetwork.tsx
@@ -18,7 +18,7 @@ export const SelectNetwork = () => {
 
   return (
     <Listbox value={chain.id.toString()} onChange={onValueChange}>
-      <div className="relative">
+      <div className="relative z-10">
         <Listbox.Button
           as={Button}
           iconRight="caret-down"


### PR DESCRIPTION
**Description**
Fixes opening select network modal on mobile while with menu open

**previously**
<img width="411" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/e10f9933-9ebf-4909-9a55-55fb0fc708f8">

**now**
<img width="396" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/35ede510-51a1-4fe4-9ba8-a1da4f33a1af">
