### PR TITLE
update: change Button prop name "action" to "variant"

### DIFF
--- a/packages/app/app/ui/page.tsx
+++ b/packages/app/app/ui/page.tsx
@@ -148,7 +148,7 @@ export default function Page() {
         </UISubSection>
         <UISubSection title="Secondary">
           <Button
-            action="secondary"
+            variant="secondary"
             iconLeft="plus"
             onClick={() => console.log("hey")}
             size="lg"
@@ -156,18 +156,18 @@ export default function Page() {
             Try Stackly now
           </Button>
           <Button
-            action="secondary"
+            variant="secondary"
             size="icon"
             iconRight="close"
             onClick={() => console.log("hey")}
           ></Button>
-          <ButtonLink action="secondary" size="sm" href="/">
+          <ButtonLink variant="secondary" size="sm" href="/">
             Soy un ButtonLink
           </ButtonLink>
         </UISubSection>
         <UISubSection title="Tertiary">
           <Button
-            action="tertiary"
+            variant="tertiary"
             iconLeft="plus"
             iconRight="close"
             onClick={() => console.log("hey")}
@@ -176,7 +176,7 @@ export default function Page() {
             Try Stackly now
           </Button>
           <Button
-            action="tertiary"
+            variant="tertiary"
             active={true}
             onClick={() => console.log("hey")}
           >
@@ -185,14 +185,14 @@ export default function Page() {
         </UISubSection>
         <UISubSection title="Quaternary">
           <Button
-            action="quaternary"
+            variant="quaternary"
             iconLeft="blocks"
             onClick={() => console.log("hey")}
           >
             Your stacks
           </Button>
           <Button
-            action="quaternary"
+            variant="quaternary"
             active={true}
             onClick={() => console.log("hey")}
           >
@@ -398,7 +398,7 @@ export default function Page() {
         </Toast>
         <UISubSection title="Examples">
           <Button
-            action="tertiary"
+            variant="tertiary"
             size="sm"
             onClick={() => setShowToast(true)}
           >
@@ -429,7 +429,7 @@ interface DialogModalButtonProps {
 }
 
 const DialogModalButton = ({ label, onClick }: DialogModalButtonProps) => (
-  <Button action="tertiary" size="sm" onClick={onClick}>
+  <Button variant="tertiary" size="sm" onClick={onClick}>
     {label}
   </Button>
 );

--- a/packages/app/components/ConnectButton.tsx
+++ b/packages/app/components/ConnectButton.tsx
@@ -47,7 +47,7 @@ const CustomConnectButton = ({
         </BodyText>
       )}
       <Button
-        action="tertiary"
+        variant="tertiary"
         iconRight="caret-down"
         onClick={onClick}
         size="sm"

--- a/packages/app/components/DatePicker.tsx
+++ b/packages/app/components/DatePicker.tsx
@@ -146,7 +146,7 @@ export function DatePicker({
                         </div>
                       </div>
                       <Button
-                        action="primary"
+                        variant="primary"
                         onClick={() => {
                           const newDate = new Date(currentDate);
                           newDate.setHours(Number(hours));

--- a/packages/app/components/SelectNetwork.tsx
+++ b/packages/app/components/SelectNetwork.tsx
@@ -23,7 +23,7 @@ export const SelectNetwork = () => {
           as={Button}
           iconRight="caret-down"
           size="sm"
-          action="tertiary"
+          variant="tertiary"
           className="flex flex-row h-10 border-none shadow-sm rounded-xl focus:bg-white focus:ring-0 active:ring-0"
         >
           <ChainIcon size={20} id={chain.id} unsupported={chain.unsupported} />

--- a/packages/app/components/StacksTable.tsx
+++ b/packages/app/components/StacksTable.tsx
@@ -103,7 +103,7 @@ export const StacksTable = ({
                 <Button
                   className="w-max"
                   size="sm"
-                  action="tertiary"
+                  variant="tertiary"
                   onClick={() => setupAndOpenModal(order)}
                 >
                   View details

--- a/packages/app/components/navbar/MenuButton.tsx
+++ b/packages/app/components/navbar/MenuButton.tsx
@@ -8,7 +8,7 @@ interface MenuButtonProps {
 export default function MenuButton({ open, toggle }: MenuButtonProps) {
   return open ? (
     <Button
-      action="secondary"
+      variant="secondary"
       iconLeft="close"
       size="icon"
       className="md:invisible"
@@ -16,7 +16,7 @@ export default function MenuButton({ open, toggle }: MenuButtonProps) {
     />
   ) : (
     <Button
-      action="secondary"
+      variant="secondary"
       iconLeft="menu"
       size="icon"
       className="md:invisible"

--- a/packages/app/components/navbar/Navbar.tsx
+++ b/packages/app/components/navbar/Navbar.tsx
@@ -24,7 +24,7 @@ export function Navbar() {
         <Divider />
         <div className="items-center justify-end hidden w-full gap-4 md:flex">
           <ButtonLink
-            action="quaternary"
+            variant="quaternary"
             size="sm"
             iconLeft="blocks"
             href="/stacks"

--- a/packages/app/components/stack-modal/StackModal.tsx
+++ b/packages/app/components/stack-modal/StackModal.tsx
@@ -137,7 +137,7 @@ export const StackModal = ({
               </Link>
             </div>
             <Button
-              action="quaternary"
+              variant="quaternary"
               iconLeft="close"
               size="icon"
               onClick={closeAction}
@@ -177,7 +177,7 @@ export const StackModal = ({
           {!stackOrder.cancelledAt && !stackIsComplete && (
             <Button
               size="sm"
-              action="secondary"
+              variant="secondary"
               onClick={() => openModal(ModalId.CANCEL_STACK_CONFIRM)}
               width="full"
             >

--- a/packages/app/components/stackbox/ConfirmStackModal.tsx
+++ b/packages/app/components/stackbox/ConfirmStackModal.tsx
@@ -131,13 +131,13 @@ export const ConfirmStackModal = ({
       </ModalContent>
       <ModalFooter>
         {step === CREATE_STACK_STEPS.create && (
-          <Button action="tertiary" onClick={closeAction} width="full">
+          <Button variant="tertiary" onClick={closeAction} width="full">
             Cancel
           </Button>
         )}
         {step === CREATE_STACK_STEPS.approve && (
           <Button
-            action="primary"
+            variant="primary"
             onClick={approveToken}
             width="full"
             ref={focusBtnRef}
@@ -147,7 +147,7 @@ export const ConfirmStackModal = ({
           </Button>
         )}
         <Button
-          action="primary"
+          variant="primary"
           onClick={createStack}
           width="full"
           ref={focusBtnRef}

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -218,7 +218,7 @@ export const Stackbox = () => {
                 {balanceOptions.map(({ name, divider }) => (
                   <Button
                     key={name}
-                    action="secondary"
+                    variant="secondary"
                     width="fit"
                     size="xs"
                     onClick={() => {
@@ -374,7 +374,7 @@ const SelectTokenButton = ({
       <BodyText className="text-em-low">{label}</BodyText>
       {token ? (
         <Button
-          action="secondary"
+          variant="secondary"
           className="leading-6 rounded-xl"
           onClick={handleButtonClick}
           size="sm"
@@ -385,7 +385,7 @@ const SelectTokenButton = ({
         </Button>
       ) : (
         <Button
-          action="secondary"
+          variant="secondary"
           className={cx("leading-6 rounded-xl", className)}
           onClick={handleButtonClick}
           size="sm"

--- a/packages/app/components/token-picker/TokenPicker.tsx
+++ b/packages/app/components/token-picker/TokenPicker.tsx
@@ -215,7 +215,7 @@ const TokenList = ({
             <div className="flex items-center justify-center flex-col mt-8 space-y-4">
               <EmptyStateTokenPickerImg />
               <BodyText>{`Nothing found for "${tokenSearchQuery}"`}</BodyText>
-              <Button action="secondary" onClick={handleClearSearch} size="md">
+              <Button variant="secondary" onClick={handleClearSearch} size="md">
                 Clear search
               </Button>
             </div>

--- a/packages/app/ui/Calendar.tsx
+++ b/packages/app/ui/Calendar.tsx
@@ -26,7 +26,7 @@ function Calendar({
         caption_label: "text-sm font-medium",
         nav: "space-x-1 flex items-center",
         nav_button: twMerge(
-          buttonStyles({ size: "icon", action: "quaternary" }),
+          buttonStyles({ size: "icon", variant: "quaternary" }),
           "h-7 w-7 bg-transparent p-0 rounded-full border border-surface-50"
         ),
         nav_button_previous: "absolute left-1",
@@ -37,7 +37,7 @@ function Calendar({
         row: "flex w-full mt-2",
         cell: "text-center text-sm p-0 relative [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
         day: twMerge(
-          buttonStyles({ size: "icon", action: "quaternary" }),
+          buttonStyles({ size: "icon", variant: "quaternary" }),
           "h-9 w-9 p-0 font-normal aria-selected:opacity-100 hover:enabled:bg-primary-400 focus:bg-primary-400 disabled:bg-transparent active:ring-primary-200 focus:ring-primary-200"
         ),
         day_selected: "bg-primary-400 text-primary-foreground ",
@@ -51,10 +51,10 @@ function Calendar({
       }}
       components={{
         IconLeft: ({ ...props }) => (
-          <Icon name="caret-left" className="h-4 w-4" />
+          <Icon name="caret-left" className="w-4 h-4" />
         ),
         IconRight: ({ ...props }) => (
-          <Icon name="caret-right" className="h-4 w-4" />
+          <Icon name="caret-right" className="w-4 h-4" />
         ),
       }}
       {...props}

--- a/packages/app/ui/buttons/Button.tsx
+++ b/packages/app/ui/buttons/Button.tsx
@@ -13,7 +13,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       children,
       className,
       size = "md",
-      action,
+      variant,
       width,
       disabled,
       onClick,
@@ -32,7 +32,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         className={twMerge(
           buttonStyles({
             size,
-            action,
+            variant,
             width,
             disabled,
             active,

--- a/packages/app/ui/buttons/ButtonLink.tsx
+++ b/packages/app/ui/buttons/ButtonLink.tsx
@@ -12,7 +12,7 @@ export function ButtonLink({
   children,
   className,
   size,
-  action,
+  variant,
   width,
   disabled,
   href,
@@ -28,7 +28,7 @@ export function ButtonLink({
       tabIndex={0}
       className={buttonStyles({
         size,
-        action,
+        variant,
         width,
         disabled,
         active,

--- a/packages/app/ui/buttons/ChipButton.tsx
+++ b/packages/app/ui/buttons/ChipButton.tsx
@@ -43,7 +43,7 @@ export function ChipButton({
       className={twMerge(
         buttonStyles({
           size,
-          action: "tertiary",
+          variant: "tertiary",
           width: null,
           disabled,
           active,

--- a/packages/app/ui/buttons/base.ts
+++ b/packages/app/ui/buttons/base.ts
@@ -19,7 +19,7 @@ export const buttonStyles = cva(
         xs: "px-2 py-1 text-xs space-x-1",
         icon: "p-2",
       },
-      action: {
+      variant: {
         primary: [
           "bg-primary-400 text-em-high hover:bg-primary-500 active:ring-primary-200 shadow-xs",
           "focus:bg-primary-500 focus:ring-primary-200",
@@ -51,29 +51,29 @@ export const buttonStyles = cva(
     },
     compoundVariants: [
       {
-        action: ["primary"],
+        variant: ["primary"],
         active: true,
         class: "bg-primary-500 ring-primary-200",
       },
       {
-        action: ["secondary"],
+        variant: ["secondary"],
         active: true,
         class: "bg-gray-100 ring-gray-200",
       },
       {
-        action: ["tertiary"],
+        variant: ["tertiary"],
         active: true,
         class: "bg-surface-75 ring-gray-100",
       },
       {
-        action: ["quaternary"],
+        variant: ["quaternary"],
         active: true,
         class: "bg-surface-50 ring-surface-75",
       },
     ],
     defaultVariants: {
       active: false,
-      action: "primary",
+      variant: "primary",
       size: "md",
       width: "normal",
       disabled: false,
@@ -86,7 +86,7 @@ export type SizeProps = "xs" | "sm" | "md" | "lg" | "icon";
 export interface ButtonBaseProps
   extends ButtonHTMLAttributes<HTMLButtonElement> {
   children?: React.ReactNode;
-  action?: "primary" | "secondary" | "tertiary" | "quaternary";
+  variant?: "primary" | "secondary" | "tertiary" | "quaternary";
   className?: string;
   size?: SizeProps;
   width?: "normal" | "fit" | "full";

--- a/packages/app/ui/dialog/DialogFooterActions.tsx
+++ b/packages/app/ui/dialog/DialogFooterActions.tsx
@@ -19,7 +19,7 @@ export const DialogFooterActions = forwardRef<
         <Button
           size="sm"
           width="full"
-          action="tertiary"
+          variant="tertiary"
           onClick={secondaryAction}
           className="text-white border-none bg-opacity-20 hover:bg-opacity-30 focus:bg-opacity-30 focus:ring-gray-600 active:ring-gray-700"
         >

--- a/packages/app/ui/modal/ModalHeaderTitle.tsx
+++ b/packages/app/ui/modal/ModalHeaderTitle.tsx
@@ -12,7 +12,7 @@ export const ModalHeaderTitle = ({
   <ModalHeader>
     <TitleText size={2}>{title}</TitleText>
     <Button
-      action="quaternary"
+      variant="quaternary"
       iconLeft="close"
       onClick={closeAction}
       size="icon"

--- a/packages/app/ui/toast/Toast.tsx
+++ b/packages/app/ui/toast/Toast.tsx
@@ -75,7 +75,7 @@ export const Toast = ({
         )}
 
         <Button
-          action="quaternary"
+          variant="quaternary"
           className="ml-3"
           iconLeft="close"
           onClick={closeAction}


### PR DESCRIPTION
Our action props works as a `variant`, applying different styles depending on the prop name. 
`Action` was bit misleading.
