### PR TITLE
fix: select token button overlaping elements

### DIFF
--- a/packages/app/app/page.tsx
+++ b/packages/app/app/page.tsx
@@ -2,7 +2,7 @@ import { Stackbox } from "@/components";
 
 export default function Home() {
   return (
-    <div className="w-full px-4 mx-auto">
+    <div className="w-full mx-auto">
       <Stackbox />
     </div>
   );

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -174,7 +174,7 @@ export const Stackbox = () => {
           />
           <Icon
             name="arrow-left"
-            className="flex items-center justify-center w-16 p-2 rotate-180 h-9 bg-surface-50 rounded-2xl"
+            className="flex items-center justify-center w-10 p-2 rotate-180 md:w-16 h-9 bg-surface-50 rounded-2xl"
           />
           <SelectTokenButton
             label="To receive"
@@ -300,7 +300,7 @@ export const Stackbox = () => {
                 </div>
               </div>
               {showDateTimeError && (
-                <div className="flex space-x-1 items-center text-danger-500">
+                <div className="flex items-center space-x-1 text-danger-500">
                   <Icon name="warning" size={12} />
                   <BodyText size={1}>
                     Please select an end time after start time
@@ -375,7 +375,7 @@ const SelectTokenButton = ({
       {token ? (
         <Button
           action="secondary"
-          className="leading-6 rounded-xl"
+          className="px-2 leading-6 md:px-4 rounded-xl"
           onClick={handleButtonClick}
           size="sm"
         >


### PR DESCRIPTION

**previously**
<img width="362" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/ebc1448c-e2df-4368-9b63-d0c538da7adf">
<img width="408" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/e6c88ac3-c9f9-4680-8d48-a7305c1313c0">

**Now**
<img width="426" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/ea7ef3db-5d8e-4a84-811f-c909f2dc6f0d">
<img width="403" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/3267d2bf-ee30-41ac-aa23-239de85b6aeb">

