### PR TITLE
[STK-105][FEAT] - Display user's token balances

### DIFF
--- a/packages/app/components/token-picker/TokenPicker.tsx
+++ b/packages/app/components/token-picker/TokenPicker.tsx
@@ -171,7 +171,7 @@ const TokenListRow = ({ onTokenSelect, token }: TokenListRowProps) => {
 
   return (
     <div
-      className="flex justify-between w-full py-2 cursor-pointer hover:bg-surface-50"
+      className="flex items-center justify-between w-full h-16 px-4 cursor-pointer hover:bg-surface-50"
       key={token.address}
       onClick={() => onTokenSelect(token)}
     >

--- a/packages/app/components/token-picker/TokenPicker.tsx
+++ b/packages/app/components/token-picker/TokenPicker.tsx
@@ -178,7 +178,7 @@ const TokenListRow = ({ onTokenSelect, token }: TokenListRowProps) => {
       <div className="flex items-center justify-between w-full">
         <div className="flex items-center space-x-3">
           <TokenIcon token={token} size="md" />
-          <div className="flex flex-col">
+          <div>
             <BodyText size={2}>{token.symbol}</BodyText>
             <BodyText className="text-em-low" size={1}>
               {token.name}

--- a/packages/app/utils/token.ts
+++ b/packages/app/utils/token.ts
@@ -1,13 +1,3 @@
-const getZeroDecimalsCount = (value: string) => {
-  if (!value) return 0;
-
-  const firstDecimalZeroIndex = value
-    .split("")
-    .findIndex((digit: string) => digit >= "1");
-
-  return firstDecimalZeroIndex === -1 ? 0 : firstDecimalZeroIndex;
-};
-
 export const addressShortner = (address: string) =>
   address.slice(0, 4) + "..." + address.slice(-4);
 
@@ -17,13 +7,10 @@ export const formatTokenValue = (
 ) => {
   if (value === 0) return value.toFixed(2);
 
-  const [wholePart, decimalPart] = value.toString().split(".");
-
-  const relevantZeroDecimalCount = getZeroDecimalsCount(decimalPart);
   const relevantZeroDecimals = new Array(decimals - 1).fill(0).join("");
 
   const formattedValue =
-    relevantZeroDecimalCount >= decimals && wholePart < "1"
+    value < `0.${relevantZeroDecimals}1`
       ? `< 0.${relevantZeroDecimals}1`
       : Number(value).toFixed(decimals);
 

--- a/packages/app/utils/token.ts
+++ b/packages/app/utils/token.ts
@@ -1,8 +1,31 @@
+const getZeroDecimalsCount = (value: number | string) => {
+  if (!value.toString().includes(".")) return 0;
+
+  const firstDecimalZeroIndex = value
+    .toString()
+    .split(".")[1]
+    .split("")
+    .findIndex((digit: string) => digit >= "1");
+
+  return firstDecimalZeroIndex === -1 ? 0 : firstDecimalZeroIndex;
+};
+
 export const addressShortner = (address: string) =>
   address.slice(0, 4) + "..." + address.slice(-4);
 
-export const formatTokenValue = (value: number, custom?: number) => {
+export const formatTokenValue = (
+  value: number | string,
+  decimals: number = 4
+) => {
   if (value === 0) return value.toFixed(2);
 
-  return custom ? value.toFixed(custom) : value.toFixed(4);
+  const nonRelevantZeroes = getZeroDecimalsCount(value);
+  const relevantZeroDecimals = new Array(decimals - 1).fill(0).join("");
+
+  const formattedValue =
+    nonRelevantZeroes >= decimals
+      ? `< 0.${relevantZeroDecimals}1`
+      : Number(value).toFixed(decimals);
+
+  return formattedValue;
 };

--- a/packages/app/utils/token.ts
+++ b/packages/app/utils/token.ts
@@ -1,9 +1,7 @@
-const getZeroDecimalsCount = (value: number | string) => {
-  if (!value.toString().includes(".")) return 0;
+const getZeroDecimalsCount = (value: string) => {
+  if (!value) return 0;
 
   const firstDecimalZeroIndex = value
-    .toString()
-    .split(".")[1]
     .split("")
     .findIndex((digit: string) => digit >= "1");
 
@@ -19,11 +17,13 @@ export const formatTokenValue = (
 ) => {
   if (value === 0) return value.toFixed(2);
 
-  const nonRelevantZeroes = getZeroDecimalsCount(value);
+  const [wholePart, decimalPart] = value.toString().split(".");
+
+  const relevantZeroDecimalCount = getZeroDecimalsCount(decimalPart);
   const relevantZeroDecimals = new Array(decimals - 1).fill(0).join("");
 
   const formattedValue =
-    nonRelevantZeroes >= decimals
+    relevantZeroDecimalCount >= decimals && wholePart < "1"
       ? `< 0.${relevantZeroDecimals}1`
       : Number(value).toFixed(decimals);
 


### PR DESCRIPTION
## Fixes: [STK-105](https://linear.app/swaprdev/issue/STK-75/add-toast-component)

### Description

* Updated Modal logic to opt-out the background opacity
* Created the Toast component
* Updated UI page where we display Stackly components

### Preview
![image](https://github.com/SwaprHQ/stackly-ui/assets/21271189/7819c40b-9744-462f-92e0-68aa7c6be634)
![image](https://github.com/SwaprHQ/stackly-ui/assets/21271189/07f0e7ad-06cf-4283-8e9a-2810a188413b)

### How to test the changes
1) Pull this branch
2) Run the project locally
3) Go to the Stackly homepage, connect your wallet, and then click any of the two "Select token" buttons