### PR TITLE
fix: remove layout max-witdh

### DIFF
--- a/packages/app/app/layout.tsx
+++ b/packages/app/app/layout.tsx
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en">
-      <body className="max-w-screen-xl px-4 mx-auto font-sans bg-surface-25">
+      <body className="px-4 mx-auto font-sans bg-surface-25">
         <Providers>
           <Navbar />
           {children}


### PR DESCRIPTION
**Description** 
Navbar should be full-width.

Fix:
- remove max width from layout

**previously**
<img width="1467" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/83ec44bd-9bd9-4b63-9093-2da7c7f2e227">

**now**
<img width="1470" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/c1a5217b-4c8b-4d59-b2f3-df879424ec71">


comments:
https://web.ruttl.com/share/gWnw47S1jJZvzZcB4eez