### PR TITLE
fix: when no address it Stackbox should show connect button

### DIFF
--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/ui";
 import {
   ConfirmStackModal,
+  ConnectButton,
   DatePicker,
   TokenIcon,
   TokenPicker,
@@ -327,14 +328,22 @@ export const Stackbox = () => {
             </div>
           </div>
         </div>
-        <Button
-          width="full"
-          size="lg"
-          onClick={openConfirmStack}
-          className={cx({ "animate-wiggle": showInsufficentBalanceError })}
-        >
-          {showInsufficentBalanceError ? "Insufficent Balance" : "Stack Now"}
-        </Button>
+        {address ? (
+          <Button
+            width="full"
+            size="lg"
+            onClick={openConfirmStack}
+            className={cx({ "animate-wiggle": showInsufficentBalanceError })}
+          >
+            {showInsufficentBalanceError ? "Insufficent Balance" : "Stack Now"}
+          </Button>
+        ) : (
+          <ConnectButton
+            size="lg"
+            className="w-full"
+            text="Connect Wallet to Stack"
+          />
+        )}
       </div>
       <TokenPicker
         closeAction={() => closeModal(ModalId.TOKEN_PICKER)}


### PR DESCRIPTION
When no `address` Stackbox  should show  Connect button

<img width="702" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/8e3ff941-cd73-49e3-bd72-fbcf9321fc1f">

ps: the proper size of the button will be updated when #64 merges.