### PR TITLE
fix: stack table row button alignment and add subtle shadow

### DIFF
--- a/packages/app/components/StacksTable.tsx
+++ b/packages/app/components/StacksTable.tsx
@@ -118,7 +118,7 @@ export const StacksTable = ({
                   )}
                 </CellWrapper>
               </TableCell>
-              <TableCell className="flex justify-end">
+              <TableCell>
                 <Button
                   className="w-max"
                   size="sm"

--- a/packages/app/components/StacksTable.tsx
+++ b/packages/app/components/StacksTable.tsx
@@ -55,7 +55,7 @@ export const StacksTable = ({
   };
 
   return (
-    <div className="w-full bg-white border rounded-3xl border-surface-50">
+    <div className="w-full bg-white border shadow-xs rounded-3xl border-surface-50">
       <Table>
         <TableHeader>
           <TableRow className="h-10 md:h-12">


### PR DESCRIPTION
Fix button alignment on the table row and adds subtle shadow to table.

**fix row button alignment** 
<img width="1169" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/2e3664f0-063d-4f18-82b2-39405c1701ae">
**Shadow**
<img width="1089" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/33e0d8ff-0e0d-42df-baea-c0ae0d367917">
