### PR TITLE
fix: extra border on end date input on desktop and outline

### DIFF
--- a/packages/app/components/DatePicker.tsx
+++ b/packages/app/components/DatePicker.tsx
@@ -60,7 +60,7 @@ export function DatePicker({
           <Popover.Button
             ref={setReferenceElement as Ref<HTMLButtonElement>}
             className={twMerge(
-              "flex justify-between items-center focus:border-0",
+              "flex justify-between items-center focus:border-0 outline-0",
               className
             )}
           >

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -296,7 +296,7 @@ export const Stackbox = () => {
               })}
             </div>
             <div className="space-y-1">
-              <div className="flex flex-col border divide-y md:flex-row rounded-2xl border-surface-50 md:divide-x divide-surface-50">
+              <div className="flex flex-col border divide-y md:divide-y-0 md:flex-row rounded-2xl border-surface-50 md:divide-x divide-surface-50">
                 <div className="flex flex-col w-full p-3 space-y-2 hover:bg-surface-25">
                   <BodyText size={2}>Starting from</BodyText>
                   <DatePicker
@@ -374,6 +374,7 @@ export const Stackbox = () => {
         title="Your stack creation was successful"
       >
         <Link
+          passHref
           className="flex items-center space-x-0.5 hover:border-em-low border-b-2 border-em-disabled group"
           href="/stacks"
           onClick={() => closeModal(ModalId.SUCCESS_STACK_TOAST)}

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/ui";
 import {
   ConfirmStackModal,
+  ConnectButton,
   DatePicker,
   TokenIcon,
   TokenPicker,
@@ -327,13 +328,21 @@ export const Stackbox = () => {
             </div>
           </div>
         </div>
-        <Button
-          width="full"
-          onClick={openConfirmStack}
-          className={cx({ "animate-wiggle": showInsufficentBalanceError })}
-        >
-          {showInsufficentBalanceError ? "Insufficent Balance" : "Stack Now"}
-        </Button>
+        {address ? (
+          <Button
+            width="full"
+            onClick={openConfirmStack}
+            className={cx({ "animate-wiggle": showInsufficentBalanceError })}
+          >
+            {showInsufficentBalanceError ? "Insufficent Balance" : "Stack Now"}
+          </Button>
+        ) : (
+          <ConnectButton
+            // size="lg"
+            className="w-full"
+            text="Connect Wallet to Stack"
+          />
+        )}
       </div>
       <TokenPicker
         closeAction={() => closeModal(ModalId.TOKEN_PICKER)}

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -378,7 +378,6 @@ export const Stackbox = () => {
         <Link
           passHref
           className="flex items-center space-x-0.5 hover:border-em-low border-b-2 border-em-disabled group"
-          passHref
           href="/stacks"
           onClick={() => closeModal(ModalId.SUCCESS_STACK_TOAST)}
         >


### PR DESCRIPTION
fixes double border:

<img width="566" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/fc2595e2-3e81-437e-acf3-7ddeaec73e11">

And remove outline when clicking the date