### PR TITLE
fix: do not allow negative numbers on input

### DIFF
--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -205,6 +205,7 @@ export const Stackbox = () => {
         </div>
         <div className="px-5 py-2">
           <input
+            min={0}
             type="number"
             pattern="[0-9]*"
             placeholder="0.0"


### PR DESCRIPTION
fixes this 👇 
<img width="753" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/9df65f67-4448-46b8-9625-75f759a5e98d">
