### PR TITLE
fix: add ability to close loading transaction Dialog

### DIFF
--- a/packages/app/components/stack-modal/StackModal.tsx
+++ b/packages/app/components/stack-modal/StackModal.tsx
@@ -234,6 +234,7 @@ export const StackModal = ({
         />
       </Dialog>
       <DialogConfirmTransactionLoading
+        closeAction={() => closeModal(ModalId.CANCEL_STACK_PROCESSING)}
         isOpen={isModalOpen(ModalId.CANCEL_STACK_PROCESSING)}
         title={cancellationTx && "Proceeding cancellation"}
         description={cancellationTx && "Waiting for transaction confirmation."}

--- a/packages/app/components/stackbox/ConfirmStackModal.tsx
+++ b/packages/app/components/stackbox/ConfirmStackModal.tsx
@@ -264,6 +264,7 @@ export const ConfirmStackModal = ({
         {approveTx?.hash && <TransactionLink hash={approveTx.hash} />}
       </DialogConfirmTransactionLoading>
       <DialogConfirmTransactionLoading
+        closeAction={() => closeModal(ModalId.STACK_CREATION_PROCESSING)}
         isOpen={isModalOpen(ModalId.STACK_CREATION_PROCESSING)}
         title={stackCreationTx && "Proceeding stack creation"}
         description={stackCreationTx && "Waiting for transaction confirmation."}


### PR DESCRIPTION
Add ability to close this dialogs:

**on cancel**
<img width="1080" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/53214823-d8aa-4997-8fe1-08eafbb64d4d">

**on create**
<img width="786" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/fd101c93-0c23-4863-8eec-09fb935cd9bb">
