### PR TITLE
fix: add logic to  not enable to select the same token on both sides

### DIFF
--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -143,7 +143,17 @@ export const Stackbox = () => {
       openModal(ModalId.CONFIRM_STACK);
     }
   };
-  const selectToken = isPickingFromToken ? setFromToken : setToToken;
+
+  const selectToken = (selectedToken: TokenFromTokenlist) => {
+    const setSelectedToken = isPickingFromToken ? setFromToken : setToToken;
+    const setOppositeToken = isPickingFromToken ? setToToken : setFromToken;
+    const oppositeToken = isPickingFromToken ? toToken : fromToken;
+    const previousToken = isPickingFromToken ? fromToken : toToken;
+
+    setSelectedToken(selectedToken);
+
+    if (oppositeToken === selectedToken) setOppositeToken(previousToken);
+  };
 
   const formattedBalance = (balanceData: NonNullable<typeof balance>) => {
     const SIGNIFICANT_DIGITS = 5;


### PR DESCRIPTION
**description**
we should not allow the user to select the same token twice.

**Logic example**
if user selects a token A and Token A == Token B
  - setTokenB(previousTokenA) 
     - if doesn't have previousTokenA, it will be undefined which renders the "select token")