### PR TITLE
fix: padding on StackModal, default color and more

### DIFF
--- a/packages/app/app/layout.tsx
+++ b/packages/app/app/layout.tsx
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en">
-      <body className="font-sans bg-fixed bg-surface-25 bg-auto-100 bg-matrix-gradient">
+      <body className="font-sans bg-fixed bg-surface-25 bg-auto-100 bg-matrix-gradient text-em-high">
         <Providers>
           <Navbar />
           <div className="px-4 mx-auto md:px-0">{children}</div>

--- a/packages/app/components/stack-modal/StackModal.tsx
+++ b/packages/app/components/stack-modal/StackModal.tsx
@@ -165,7 +165,7 @@ export const StackModal = ({
             />
           </div>
         </ModalHeader>
-        <ModalContent className="px-0 md:px-0">
+        <ModalContent className="px-0 space-y-4 md:px-0">
           <div className="grid grid-cols-2 gap-5 px-4 md:px-6 gap-x-8 md:grid-cols-4">
             <StackDetail title="Starts on">
               {formatTimestampToDateWithTime(firstSlot)}
@@ -188,13 +188,13 @@ export const StackModal = ({
           </div>
           <div className="w-full my-4 border-b border-surface-50"></div>
           {stackIsFinishedWithFunds(stackOrder) && (
-            <div className="px-4 pb-4 md:px-6">
+            <div className="px-4 md:px-6">
               <HasRemainingFundsAlertMessage
                 remainingFundsWithSymbol={stackRemainingFundsWithTokenText}
               />
             </div>
           )}
-          <div className="px-4 md:px-6">
+          <div className="px-4 space-y-4 md:px-6">
             <TitleText size={2} weight="bold">
               Orders
             </TitleText>
@@ -205,18 +205,19 @@ export const StackModal = ({
             )}
           </div>
         </ModalContent>
-        <ModalFooter>
-          {!stackOrder.cancelledAt && !stackIsComplete(stackOrder) && (
+        {!stackOrder.cancelledAt && !stackIsComplete(stackOrder) ? (
+          <ModalFooter>
             <Button
-              size="sm"
               variant={getConfirmCancelContent().button.action}
               onClick={() => openModal(ModalId.CANCEL_STACK_CONFIRM)}
               width="full"
             >
               {getConfirmCancelContent().button.text}
             </Button>
-          )}
-        </ModalFooter>
+          </ModalFooter>
+        ) : (
+          <div className="pb-6"></div>
+        )}
       </Modal>
       <Dialog
         isOpen={isModalOpen(ModalId.CANCEL_STACK_CONFIRM)}
@@ -266,7 +267,7 @@ export const StackModal = ({
 };
 
 const StackInfo = ({ stackOrder }: StackOrderProps) => (
-  <div className="flex flex-col justify-between gap-2 px-4 py-3 mt-6 mb-4 md:px-6 md:items-center md:flex-row bg-surface-25 rounded-2xl">
+  <div className="flex flex-col justify-between gap-2 px-4 py-3 md:px-6 md:items-center md:flex-row bg-surface-25 rounded-2xl">
     <FromToStackTokenPair
       fromToken={stackOrder.sellToken}
       fromText={formatTokenValue(totalFundsUsed(stackOrder))}

--- a/packages/app/components/stack-modal/StackModal.tsx
+++ b/packages/app/components/stack-modal/StackModal.tsx
@@ -124,6 +124,9 @@ export const StackModal = ({
     }
   };
 
+  const stackNotCancelledAndNotComplete =
+    !stackOrder.cancelledAt && !stackIsComplete(stackOrder);
+
   return (
     <>
       <Modal
@@ -208,12 +211,10 @@ export const StackModal = ({
         </ModalContent>
         <ModalFooter
           className={cx({
-            "pt-0 pb-6": !(
-              !stackOrder.cancelledAt && !stackIsComplete(stackOrder)
-            ),
+            "pt-0 pb-6": !stackNotCancelledAndNotComplete,
           })}
         >
-          {!stackOrder.cancelledAt && !stackIsComplete(stackOrder) && (
+          {stackNotCancelledAndNotComplete && (
             <Button
               variant={getConfirmCancelContent().button.action}
               onClick={() => openModal(ModalId.CANCEL_STACK_CONFIRM)}

--- a/packages/app/components/stack-modal/StackModal.tsx
+++ b/packages/app/components/stack-modal/StackModal.tsx
@@ -165,8 +165,8 @@ export const StackModal = ({
             />
           </div>
         </ModalHeader>
-        <ModalContent className="px-0">
-          <div className="grid grid-cols-2 gap-5 px-4 gap-x-8 md:grid-cols-4">
+        <ModalContent className="px-0 md:px-0">
+          <div className="grid grid-cols-2 gap-5 px-4 md:px-6 gap-x-8 md:grid-cols-4">
             <StackDetail title="Starts on">
               {formatTimestampToDateWithTime(firstSlot)}
             </StackDetail>
@@ -188,13 +188,13 @@ export const StackModal = ({
           </div>
           <div className="w-full my-4 border-b border-surface-50"></div>
           {stackIsFinishedWithFunds(stackOrder) && (
-            <div className="px-4 pb-4">
+            <div className="px-4 pb-4 md:px-6">
               <HasRemainingFundsAlertMessage
                 remainingFundsWithSymbol={stackRemainingFundsWithTokenText}
               />
             </div>
           )}
-          <div className="px-4">
+          <div className="px-4 md:px-6">
             <TitleText size={2} weight="bold">
               Orders
             </TitleText>
@@ -266,7 +266,7 @@ export const StackModal = ({
 };
 
 const StackInfo = ({ stackOrder }: StackOrderProps) => (
-  <div className="flex flex-col justify-between gap-2 px-4 py-3 mt-6 mb-4 md:items-center md:flex-row bg-surface-25 rounded-2xl">
+  <div className="flex flex-col justify-between gap-2 px-4 py-3 mt-6 mb-4 md:px-6 md:items-center md:flex-row bg-surface-25 rounded-2xl">
     <FromToStackTokenPair
       fromToken={stackOrder.sellToken}
       fromText={formatTokenValue(totalFundsUsed(stackOrder))}

--- a/packages/app/components/stack-modal/StackModal.tsx
+++ b/packages/app/components/stack-modal/StackModal.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { ReactNode, useState } from "react";
+import { cx } from "class-variance-authority";
 
 import { getOrderPairSymbols, totalOrderSlotsDone } from "@/models/order";
 import {
@@ -205,8 +206,14 @@ export const StackModal = ({
             )}
           </div>
         </ModalContent>
-        {!stackOrder.cancelledAt && !stackIsComplete(stackOrder) ? (
-          <ModalFooter>
+        <ModalFooter
+          className={cx({
+            "pt-0 pb-6": !(
+              !stackOrder.cancelledAt && !stackIsComplete(stackOrder)
+            ),
+          })}
+        >
+          {!stackOrder.cancelledAt && !stackIsComplete(stackOrder) && (
             <Button
               variant={getConfirmCancelContent().button.action}
               onClick={() => openModal(ModalId.CANCEL_STACK_CONFIRM)}
@@ -214,10 +221,8 @@ export const StackModal = ({
             >
               {getConfirmCancelContent().button.text}
             </Button>
-          </ModalFooter>
-        ) : (
-          <div className="pb-6"></div>
-        )}
+          )}
+        </ModalFooter>
       </Modal>
       <Dialog
         isOpen={isModalOpen(ModalId.CANCEL_STACK_CONFIRM)}

--- a/packages/app/components/stack-modal/StackProgress.tsx
+++ b/packages/app/components/stack-modal/StackProgress.tsx
@@ -10,7 +10,7 @@ import {
 import { formatTokenValue } from "@/utils/token";
 
 export const StackProgress = ({ stackOrder }: StackOrderProps) => (
-  <div className="mt-3 space-y-3">
+  <div className="space-y-2">
     <div className="flex flex-col justify-between space-y-1 md:space-y-0 md:items-center md:flex-row">
       <OrdersExecuted stackOrder={stackOrder} />
       <div className="flex items-center space-x-1">

--- a/packages/app/components/token-picker/TokenPicker.tsx
+++ b/packages/app/components/token-picker/TokenPicker.tsx
@@ -97,8 +97,8 @@ const TokenPicker = ({
       initialFocusRef={initialFocusRef}
     >
       <ModalHeaderTitle closeAction={handleModalClose} title="Select a token" />
-      <ModalContent className="px-0">
-        <div className="px-4">
+      <ModalContent className="px-0 md:px-0">
+        <div className="px-4 md:px-6">
           <SearchBar
             ref={initialFocusRef}
             onSearch={handleTokenSearchInput}
@@ -171,7 +171,7 @@ const TokenListRow = ({ onTokenSelect, token }: TokenListRowProps) => {
 
   return (
     <div
-      className="flex items-center justify-between w-full h-16 px-4 cursor-pointer hover:bg-surface-50"
+      className="flex items-center justify-between w-full h-16 px-4 cursor-pointer md:px-6 hover:bg-surface-50"
       key={token.address}
       onClick={() => onTokenSelect(token)}
     >

--- a/packages/app/ui/buttons/base.ts
+++ b/packages/app/ui/buttons/base.ts
@@ -29,7 +29,7 @@ export const buttonStyles = cva(
           "focus:bg-gray-100 focus:ring-surface-50",
         ],
         tertiary: [
-          "bg-white text-em-med hover:bg-surface-75 border active:ring-surface-50 shadow-xs",
+          "bg-white text-em-med hover:bg-surface-75 border border-surface-50  active:ring-surface-50 shadow-xs",
           "focus:bg-surface-75 focus:ring-surface-50",
         ],
         quaternary: [

--- a/packages/app/ui/modal/ModalContent.tsx
+++ b/packages/app/ui/modal/ModalContent.tsx
@@ -9,5 +9,7 @@ interface ModalContentProps extends PropsWithChildren {
 }
 
 export function ModalContent({ children, className }: ModalContentProps) {
-  return <div className={twMerge("px-4 mt-5", className)}>{children}</div>;
+  return (
+    <div className={twMerge("px-4 mt-5 md:px-6", className)}>{children}</div>
+  );
 }

--- a/packages/app/ui/modal/ModalFooter.tsx
+++ b/packages/app/ui/modal/ModalFooter.tsx
@@ -1,10 +1,20 @@
 "use client";
 
 import { PropsWithChildren } from "react";
+import { twMerge } from "tailwind-merge";
 
-export const ModalFooter = ({ children }: PropsWithChildren) => {
+interface ModalFooterProps extends PropsWithChildren {
+  className?: string;
+}
+
+export const ModalFooter = ({ children, className }: ModalFooterProps) => {
   return (
-    <div className="flex items-center px-4 py-6 space-x-2 md:px-6">
+    <div
+      className={twMerge(
+        "flex items-center px-4 pb-6 pt-6 space-x-2 md:px-6",
+        className
+      )}
+    >
       {children}
     </div>
   );

--- a/packages/app/ui/modal/ModalFooter.tsx
+++ b/packages/app/ui/modal/ModalFooter.tsx
@@ -4,6 +4,8 @@ import { PropsWithChildren } from "react";
 
 export const ModalFooter = ({ children }: PropsWithChildren) => {
   return (
-    <div className="flex items-center px-4 py-5 space-x-2">{children}</div>
+    <div className="flex items-center px-4 py-5 space-x-2 md:px-6">
+      {children}
+    </div>
   );
 };

--- a/packages/app/ui/modal/ModalFooter.tsx
+++ b/packages/app/ui/modal/ModalFooter.tsx
@@ -4,7 +4,7 @@ import { PropsWithChildren } from "react";
 
 export const ModalFooter = ({ children }: PropsWithChildren) => {
   return (
-    <div className="flex items-center px-4 py-5 space-x-2 md:px-6">
+    <div className="flex items-center px-4 py-6 space-x-2 md:px-6">
       {children}
     </div>
   );

--- a/packages/app/ui/modal/ModalHeader.tsx
+++ b/packages/app/ui/modal/ModalHeader.tsx
@@ -8,7 +8,7 @@ export function ModalHeader({ children }: PropsWithChildren) {
   return (
     <Dialog.Title
       as="div"
-      className="flex items-center justify-between w-full px-4 py-3 border-b border-surface-50"
+      className="flex items-center justify-between w-full px-4 py-4 border-b md:px-6 border-surface-50"
     >
       {children}
     </Dialog.Title>


### PR DESCRIPTION
**summary**
- add default color to body
- add lighter border color to "tertiary" button
- check modal padding x (24px)
- stack modal header padding y
- consistent padding inside Stack modal

**images**
<img width="370" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/673f1f7d-2df4-4524-8ee5-a0af7f6a1cb7">
<img width="770" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/8658116c-a47e-4023-8f73-147f3c159b96">
