### PR TITLE
[STK-141][FEAT] - Add start datetime logic

### DIFF
--- a/packages/app/components/DatePicker.tsx
+++ b/packages/app/components/DatePicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { format, isToday, isTomorrow } from "date-fns";
+import { format, isSameMinute, isToday, isTomorrow } from "date-fns";
 
 import { Button, Calendar, Icon } from "@/ui";
 import { Popover } from "@headlessui/react";
@@ -16,6 +16,8 @@ interface DatePickerProps {
   timeCaption: string;
   fromDate?: Date;
 }
+
+const getDateInMins = (dateInMs: number) => Math.floor(dateInMs / (1000 * 60));
 
 export function DatePicker({
   dateTime,
@@ -40,6 +42,7 @@ export function DatePicker({
   });
 
   const formattedDate = () => {
+    if (isSameMinute(dateTime, Date.now())) return "Now";
     if (isToday(dateTime)) return format(dateTime, "'Today at' HH:mm");
     if (isTomorrow(dateTime)) return format(dateTime, "'Tomorrow at' HH:mm");
 

--- a/packages/app/components/DatePicker.tsx
+++ b/packages/app/components/DatePicker.tsx
@@ -17,8 +17,6 @@ interface DatePickerProps {
   fromDate?: Date;
 }
 
-const getDateInMins = (dateInMs: number) => Math.floor(dateInMs / (1000 * 60));
-
 export function DatePicker({
   dateTime,
   setDateTime,

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -128,7 +128,7 @@ export const Stackbox = () => {
       new Date().setMinutes(
         new Date().getMinutes() + START_TIME_MINUTES_OFFSET
       );
-    const tokenAmountIsZero = tokenAmount === "0";
+    const isTokenAmountZero = tokenAmount === "0";
 
     setShowPastEndDateError(isEndTimeBeforeStartTime);
     setShowPastStartDateError(isStartTimeBefore10minsFromNow);
@@ -153,9 +153,9 @@ export const Stackbox = () => {
       fromToken &&
       toToken &&
       tokenAmount &&
-      !tokenAmountIsZero &&
       !isEndTimeBeforeStartTime &&
       !isStartTimeBefore10minsFromNow &&
+      !isTokenAmountZero &&
       balance &&
       BigInt(balance.value) >= parseUnits(tokenAmount, fromToken.decimals)
     ) {

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -121,16 +121,17 @@ export const Stackbox = () => {
 
   const openConfirmStack = () => {
     const startDate = startDateTime.getTime();
-    const endTimeBeforeStartTime = endDateTime.getTime() <= startDate;
-    const startTimeBefore10minsFromNow =
+    const endDate = endDateTime.getTime();
+    const isEndTimeBeforeStartTime = endDate <= startDate;
+    const isStartTimeBefore10minsFromNow =
       startDate <=
       new Date().setMinutes(
         new Date().getMinutes() + START_TIME_MINUTES_OFFSET
       );
     const tokenAmountIsZero = tokenAmount === "0";
 
-    setShowPastEndDateError(endTimeBeforeStartTime);
-    setShowPastStartDateError(startTimeBefore10minsFromNow);
+    setShowPastEndDateError(isEndTimeBeforeStartTime);
+    setShowPastStartDateError(isStartTimeBefore10minsFromNow);
 
     if (!fromToken || !toToken) {
       if (!fromToken) setShowFromTokenError(true);
@@ -153,8 +154,8 @@ export const Stackbox = () => {
       toToken &&
       tokenAmount &&
       !tokenAmountIsZero &&
-      !endTimeBeforeStartTime &&
-      !startTimeBefore10minsFromNow &&
+      !isEndTimeBeforeStartTime &&
+      !isStartTimeBefore10minsFromNow &&
       balance &&
       BigInt(balance.value) >= parseUnits(tokenAmount, fromToken.decimals)
     ) {
@@ -364,7 +365,7 @@ export const Stackbox = () => {
                   className={cx(
                     "flex flex-col w-full p-3 space-y-2 hover:bg-surface-25",
                     {
-                      "border border-danger-500 rounded-l-2xl":
+                      "border border-danger-200 rounded-l-2xl":
                         showPastStartDateError,
                     }
                   )}
@@ -381,7 +382,7 @@ export const Stackbox = () => {
                   className={cx(
                     "flex flex-col w-full p-3 space-y-2 hover:bg-surface-25",
                     {
-                      "!border !border-danger-500 !rounded-r-2xl":
+                      "!border !border-danger-200 !rounded-r-2xl":
                         showPastEndDateError && !showPastStartDateError,
                     }
                   )}

--- a/packages/app/public/assets/icons/index.tsx
+++ b/packages/app/public/assets/icons/index.tsx
@@ -9,6 +9,7 @@ import CaretRightIcon from "./caret-right.svg";
 import CheckmarkIcon from "./check.svg";
 import CloseIcon from "./close.svg";
 import HamburgerIcon from "./hamburger.svg";
+import InfoIcon from "./info.svg";
 import PlusIcon from "./plus.svg";
 import SearchIcon from "./search.svg";
 import StacklyLogoIcon from "./stackly-logo.svg";
@@ -26,6 +27,7 @@ export {
   CheckmarkIcon,
   CloseIcon,
   HamburgerIcon,
+  InfoIcon,
   PlusIcon,
   SearchIcon,
   StacklyLogoIcon,

--- a/packages/app/public/assets/icons/info.svg
+++ b/packages/app/public/assets/icons/info.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M10 20c5.523 0 10-4.477 10-10S15.523 0 10 0 0 4.477 0 10s4.477 10 10 10Zm-1-5v-2h2v2H9ZM9 5v6h2V5H9Z" fill="currentColor"/>
+</svg>

--- a/packages/app/ui/icon/Icon.tsx
+++ b/packages/app/ui/icon/Icon.tsx
@@ -9,6 +9,7 @@ export type IconName =
   | "caret-right"
   | "check"
   | "close"
+  | "info"
   | "menu"
   | "plus"
   | "search"
@@ -33,6 +34,7 @@ export const iconMap: Record<IconName, any> = {
   "caret-right": IconList.CaretRightIcon,
   check: IconList.CheckmarkIcon,
   close: IconList.CloseIcon,
+  info: IconList.InfoIcon,
   menu: IconList.HamburgerIcon,
   plus: IconList.PlusIcon,
   search: IconList.SearchIcon,


### PR DESCRIPTION
## Fixes: 
* [STK-141](https://linear.app/swaprhq/issue/STK-141/add-start-datetime-logic)
* [STK-137](https://linear.app/swaprhq/issue/STK-137/show-error-when-creating-stack-in-the-past)

### Description

* Check if the start date is 10m or less from now, if so, display an error
* Highlight date fields that are erroring
* Allow 1 date field error at the time

### Preview
![image](https://github.com/SwaprHQ/stackly-ui/assets/21271189/6807b6d3-5396-4217-9bd4-933c6c51a42e)
![image](https://github.com/SwaprHQ/stackly-ui/assets/21271189/7319a86b-c370-46e9-8f06-e5dae12a963b)


### How to test the changes
1) Pull this branch
2) Run the project locally
3) Go to the Stackly homepage, connect your wallet
4) The current date time should be displayed in the "start time" input.
4.1) If the user selects a date that is less than 10 minutes from the current time, an error should appear
4.2) If the user has both errors for start and end date, then only 1 error at the time should be displayed