### PR TITLE
fix: update json provider

### DIFF
--- a/packages/app/providers/wagmi-config.ts
+++ b/packages/app/providers/wagmi-config.ts
@@ -1,11 +1,22 @@
 import { configureChains, createConfig } from "wagmi";
 import { getDefaultConfig } from "connectkit";
 import { gnosis } from "wagmi/chains";
-import { publicProvider } from "wagmi/providers/public";
+import { jsonRpcProvider } from "wagmi/providers/jsonRpc";
+import { ChainId } from "@stackly/sdk";
+
+const chainJsonRpc: Record<number, { http: string }> = {
+  [ChainId.GNOSIS]: {
+    http: `https://rpc.gnosis.gateway.fm`,
+  },
+};
 
 const { chains, publicClient, webSocketPublicClient } = configureChains(
   [gnosis],
-  [publicProvider()]
+  [
+    jsonRpcProvider({
+      rpc: (chain) => chainJsonRpc[chain.id],
+    }),
+  ]
 );
 
 export const config = createConfig(


### PR DESCRIPTION
Default `publicProvider` from wagmi isn't working on production. Changed to a custom RPC.