### PR TITLE
fix: Stack shows it has remaining funds when it has not

### DIFF
--- a/packages/app/models/stack-order/stack-order.ts
+++ b/packages/app/models/stack-order/stack-order.ts
@@ -45,8 +45,11 @@ export const totalStacked = (order: StackOrder) =>
     );
   }, 0) ?? 0;
 
+const SMALL_FRACTION = 0.00000001;
+
 const stackHasRemainingFunds = (stackOrder: StackOrder) =>
-  stackRemainingFunds(stackOrder) !== 0;
+  totalFundsUsed(stackOrder) > 0 &&
+  stackRemainingFunds(stackOrder) > SMALL_FRACTION;
 
 export const stackRemainingFunds = (stackOrder: StackOrder) => {
   if (totalFundsUsed(stackOrder) === 0 && totalStackOrdersDone(stackOrder) > 0)


### PR DESCRIPTION
**before**
<img width="1137" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/47b84d8b-4fa1-43c6-bad3-5441303a7101">
<img width="740" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/56f0d2b4-fb16-4a2f-a8cf-313bdd9f61fe">

**after**
<img width="1216" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/a681c800-5d06-4870-a2bf-32db3034ca22">
<img width="750" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/296dc9ff-8c52-485c-ac1a-813d3d807a92">
