### PR TITLE
fix: safe autoconnect doesn't allow to disconnect

### DIFF
--- a/packages/app/hooks/autoConnect.ts
+++ b/packages/app/hooks/autoConnect.ts
@@ -3,13 +3,7 @@
 import { useAccount, useConnect } from "wagmi";
 import { useEffect } from "react";
 
-const AUTOCONNECTED_CONNECTOR_IDS = [
-  "safe",
-  "injected",
-  "metaMask",
-  "coinbaseWallet",
-  "walletConnect",
-];
+const AUTOCONNECTED_CONNECTOR_IDS = ["safe"];
 
 function useAutoConnect() {
   const { connect, connectors } = useConnect();

--- a/packages/app/providers/wagmi-config.ts
+++ b/packages/app/providers/wagmi-config.ts
@@ -21,7 +21,7 @@ const { chains, publicClient, webSocketPublicClient } = configureChains(
 );
 
 const defaultConfig = getDefaultConfig({
-  autoConnect: false,
+  autoConnect: true,
   alchemyId: process.env.NEXT_PUBLIC_ALCHEMY_KEY,
   walletConnectProjectId:
     process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || "",


### PR DESCRIPTION
This PR aims to fix disconnecting issue that was introduced with auto connect.

Looks like it still works on Safe:

<img width="1467" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/e1c9f5c2-281e-443f-b396-f4ab24c9f863">

The connected wallet is the Safe wallet and not the user.