### PR TITLE
update: Totals must include stackly fee

### DIFF
--- a/packages/app/components/StacksTable.tsx
+++ b/packages/app/components/StacksTable.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/ui";
 import { StackedTokenLogoPair, StackModal } from "@/components";
 import {
-  fundsAmountWithToken,
+  totalFundsAmountWithToken,
   getOrderPairSymbols,
   totalOrderSlotsDone,
 } from "@/models/order";
@@ -86,7 +86,7 @@ export const StacksTable = ({
                     {formatTokenValue(totalFundsUsed(order), 2)}
                   </BodyText>
                   <BodyText className="text-em-low">
-                    / {fundsAmountWithToken(order)}
+                    / {totalFundsAmountWithToken(order)}
                   </BodyText>
                 </CellWrapper>
               </TableCell>

--- a/packages/app/components/stack-modal/StackProgress.tsx
+++ b/packages/app/components/stack-modal/StackProgress.tsx
@@ -1,4 +1,4 @@
-import { fundsAmountWithToken, totalOrderSlotsDone } from "@/models/order";
+import { totalFundsAmountWithToken, totalOrderSlotsDone } from "@/models/order";
 import { OrdersProgressBar } from "@/components/OrdersProgressBar";
 import { BodyText } from "@/ui";
 import { TokenIcon } from "@/components/TokenIcon";
@@ -19,7 +19,7 @@ export const StackProgress = ({ stackOrder }: StackOrderProps) => (
           <span className="text-em-high">
             {formatTokenValue(totalFundsUsed(stackOrder), 2)}{" "}
             <span className="text-xs">of</span>{" "}
-            {fundsAmountWithToken(stackOrder)}
+            {totalFundsAmountWithToken(stackOrder)}
           </span>
         </BodyText>
         <TokenIcon size="xs" token={stackOrder.sellToken} />

--- a/packages/app/models/order/order.ts
+++ b/packages/app/models/order/order.ts
@@ -12,11 +12,18 @@ export const totalOrderSlotsDone = (order: Order) => {
 export const allOrderSlotsDone = (order: Order) =>
   totalOrderSlotsDone(order) === order.orderSlots.length;
 
-export const fundsAmount = (order: Order) =>
-  convertedAmount(order.amount, order.sellToken.decimals).toFixed(2);
+export const totalFundsAmount = (order: Order) => {
+  const total =
+    convertedAmount(order.amount, order.sellToken.decimals) + stacklyFee(order);
 
-export const fundsAmountWithToken = (order: Order) =>
-  `${fundsAmount(order)} ${order.sellToken.symbol}`;
+  return total.toFixed(2);
+};
+
+export const totalFundsAmountWithToken = (order: Order) =>
+  `${totalFundsAmount(order)} ${order.sellToken.symbol}`;
 
 export const getOrderPairSymbols = (order: Order) =>
   `${order.buyToken.symbol}/${order.sellToken.symbol}`;
+
+export const stacklyFee = (order: Order) =>
+  convertedAmount(order.feeAmount, order.sellToken.decimals);

--- a/packages/app/models/stack-order/stack-order.ts
+++ b/packages/app/models/stack-order/stack-order.ts
@@ -49,11 +49,9 @@ export const totalStacked = (order: StackOrder) =>
     );
   }, 0) ?? 0;
 
-const SMALL_FRACTION = 0.00000001;
-
 const stackHasRemainingFunds = (stackOrder: StackOrder) =>
-  totalFundsUsed(stackOrder) > 0 &&
-  stackRemainingFunds(stackOrder) > SMALL_FRACTION;
+  totalFundsUsed(stackOrder) > stacklyFee(stackOrder) &&
+  stackRemainingFunds(stackOrder) > stacklyFee(stackOrder);
 
 export const stackRemainingFunds = (stackOrder: StackOrder) => {
   if (totalFundsUsed(stackOrder) === 0 && totalStackOrdersDone(stackOrder) > 0)

--- a/packages/app/models/stack-order/stack-order.ts
+++ b/packages/app/models/stack-order/stack-order.ts
@@ -1,4 +1,4 @@
-import { allOrderSlotsDone } from "@/models/order";
+import { allOrderSlotsDone, stacklyFee } from "@/models/order";
 import { StackOrder } from "@/models/stack-order";
 import { convertedAmount } from "@/utils/numbers";
 
@@ -30,13 +30,17 @@ export const calculateStackAveragePrice = (order: StackOrder) => {
   return averagePrice;
 };
 
-export const totalFundsUsed = (order: StackOrder) =>
-  order.cowOrders?.reduce((acc, cowOrder) => {
-    return (
-      acc +
-      convertedAmount(cowOrder.executedSellAmount, order.sellToken.decimals)
-    );
-  }, 0) ?? 0;
+export const totalFundsUsed = (order: StackOrder) => {
+  const total =
+    order.cowOrders?.reduce((acc, cowOrder) => {
+      return (
+        acc +
+        convertedAmount(cowOrder.executedSellAmount, order.sellToken.decimals)
+      );
+    }, 0) ?? 0;
+
+  return total + stacklyFee(order);
+};
 
 export const totalStacked = (order: StackOrder) =>
   order.cowOrders?.reduce((acc, cowOrder) => {

--- a/packages/sdk/src/vaults/subgraph.ts
+++ b/packages/sdk/src/vaults/subgraph.ts
@@ -43,6 +43,9 @@ export type Order = {
   buyToken: Token;
   /**  Amount of the vault  */
   amount: Scalars["Float"];
+  /**  stackly fees  */
+  feeAmount: Scalars["Float"];
+  fee: Scalars["Float"];
   /**  Start time of the vault  */
   startTime: Scalars["Int"];
   /**  End time of the vault  */
@@ -60,6 +63,8 @@ const OrderFragment = gql`
     owner
     receiver
     amount
+    fee
+    feeAmount
     sellToken {
       id
       address


### PR DESCRIPTION
Add fee to `totalFundsAmount` and `totalFundsUsed`

improve names: `totalFundsAmountWithToken` and `totalFundsAmount`

**SDK update**
- get fee and `feeAmount` from sdk
- add fee and feeAmount to sdk type Order

Also update `stackHasRemainingFunds` to use stackly fee


**before**
<img width="1071" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/e60ce6ad-778b-448f-beea-ad7b8d597374">

**now**
<img width="1054" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/b0046c63-182f-42ad-96db-d0fa4d5e84a9">
