### PR TITLE
[STK-175][FEAT] - Update Stackbox logic to forbid start time in the past

### DIFF
--- a/packages/app/components/DatePicker.tsx
+++ b/packages/app/components/DatePicker.tsx
@@ -11,7 +11,7 @@ import { twMerge } from "tailwind-merge";
 
 interface DatePickerProps {
   dateTime: Date;
-  setDateTime: Dispatch<SetStateAction<Date>>;
+  setDateTime: Dispatch<SetStateAction<Date>> | ((date: Date) => void);
   className?: string;
   timeCaption: string;
   fromDate?: Date;

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -204,6 +204,16 @@ export const Stackbox = () => {
     );
   };
 
+  const handleStartDateTimeChange = (newDateTime: Date) => {
+    const dateNowInMs = Date.now();
+    const newStartDate =
+      newDateTime.getTime() <= dateNowInMs
+        ? new Date(dateNowInMs)
+        : newDateTime;
+
+    setStartDateTime(newStartDate);
+  };
+
   const estimatedNumberOfOrders =
     Math.floor(
       (endDateTime.getTime() - startDateTime.getTime()) /
@@ -362,7 +372,7 @@ export const Stackbox = () => {
                   <BodyText size={2}>Starting from</BodyText>
                   <DatePicker
                     dateTime={startDateTime}
-                    setDateTime={setStartDateTime}
+                    setDateTime={handleStartDateTimeChange}
                     timeCaption="Start time"
                     className="w-full"
                   />
@@ -398,7 +408,7 @@ export const Stackbox = () => {
           </div>
         </div>
         {fromToken && toToken && tokenAmount && tokenAmount > "0" && (
-          <div className="p-2 bg-surface-25 text-center text-em-low rounded-xl">
+          <div className="p-2 text-center bg-surface-25 text-em-low rounded-xl">
             <BodyText size={1}>
               Stacks <span className="text-em-med">{toToken.symbol}</span>,
               worth{" "}

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -205,11 +205,8 @@ export const Stackbox = () => {
   };
 
   const handleStartDateTimeChange = (newDateTime: Date) => {
-    const dateNowInMs = Date.now();
     const newStartDate =
-      newDateTime.getTime() <= dateNowInMs
-        ? new Date(dateNowInMs)
-        : newDateTime;
+      newDateTime.getTime() <= Date.now() ? new Date(Date.now()) : newDateTime;
 
     setStartDateTime(newStartDate);
   };


### PR DESCRIPTION
## Fixes: [STK-175](https://linear.app/swaprhq/issue/STK-175/set-stackbox-start-time-as-now-on-past-times-input)

### Description

* Overwrite selected StartTime for the Stackbox, if the date is in the past

### Preview
https://www.loom.com/share/eb14ef3c7de54b6baf45368e31d80d8f?sid=bd8bd3ae-7a03-45ea-bb7a-7350b49f0643


### How to test the changes
1) Pull this branch
2) Run the project locally
3) Go to the Stackly homepage, connect your wallet
4) "Now" text should be displayed in the "Starting from" input.
5) If the user selects a date in the past, it will be overwritten into "Now"