### PR TITLE
fix: add missing links to mobile mobile menu 

### DIFF
--- a/packages/app/app/layout.tsx
+++ b/packages/app/app/layout.tsx
@@ -5,6 +5,7 @@ import localFont from "next/font/local";
 import { Navbar } from "@/components";
 import { Providers } from "@/providers";
 import "@/styles/global.css";
+import { STACKLY_APP_URL } from "@/constants";
 
 const stabilGrotesk = localFont({
   src: [
@@ -28,10 +29,8 @@ const stabilGrotesk = localFont({
   variable: "--sans-font",
 });
 
-const defaultStacklyUrl = "https://stackly.eth.limo";
-
 export const metadata: Metadata = {
-  metadataBase: new URL(process.env.STACKLY_URL ?? defaultStacklyUrl),
+  metadataBase: new URL(STACKLY_APP_URL),
   title: "Stackly | Stack crypto over time.",
   description:
     "Stackly is a simple, non-custodial tool that uses the CoW protocol to place recurring swaps based on DCA.",

--- a/packages/app/components/navbar/MobileMenu.tsx
+++ b/packages/app/components/navbar/MobileMenu.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { ConnectButton, SelectNetwork } from "@/components";
 import Link from "next/link";
 import { Button, Icon } from "@/ui";
+import { STACKLY_LANDING_URL } from "@/constants";
 
 export default function MobileMenu() {
   const [isOpen, setIsOpen] = useState(false);
@@ -38,10 +39,16 @@ export default function MobileMenu() {
               <span className="ml-4">Your Stacks</span>
             </Link>
             <hr className="h-0 -mx-6 border-b border-solid border-surface-75" />
-            <Link href="#" className="block py-3 text-em-med">
+            <Link
+              href={`${STACKLY_LANDING_URL}#how-it-works`}
+              className="block py-3 text-em-med"
+            >
               How it works
             </Link>
-            <Link href="#" className="block py-3 text-em-med">
+            <Link
+              href={`${STACKLY_LANDING_URL}#faqs`}
+              className="block py-3 text-em-med"
+            >
               FAQ&apos;s
             </Link>
           </div>

--- a/packages/app/constants/index.ts
+++ b/packages/app/constants/index.ts
@@ -1,0 +1,5 @@
+export const STACKLY_LANDING_URL =
+  process.env.STACKLY_LANDING_URL ?? "https://stackly.app";
+
+export const STACKLY_APP_URL =
+  process.env.STACKLY_APP_URL ?? "https://stackly.eth.limo";

--- a/packages/landing/next.config.js
+++ b/packages/landing/next.config.js
@@ -10,9 +10,6 @@ const nextConfig = {
 
     return config;
   },
-  images: {
-    unoptimized: true,
-  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
- add stackly app and landing url links as constants to app
- add missing links on mobile menu
-  also remove unoptimized images from landing next config (needed for fleek on app but no need on landing.)