### PR TITLE
fix: broken empty state on select token when address was filled

### DIFF
--- a/packages/app/components/token-picker/TokenPicker.tsx
+++ b/packages/app/components/token-picker/TokenPicker.tsx
@@ -209,7 +209,7 @@ const TokenList = ({
         : tokenSearchQuery && (
             <div className="flex flex-col items-center justify-center mt-8 space-y-4">
               <EmptyStateTokenPickerImg />
-              <BodyText>{`Nothing found for "${tokenSearchQuery}"`}</BodyText>
+              <BodyText className="text-center">{`Nothing found for "${tokenSearchQuery}"`}</BodyText>
               <Button variant="secondary" onClick={handleClearSearch} size="md">
                 Clear search
               </Button>


### PR DESCRIPTION
**before**
<img width="848" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/08602b81-4c17-4a24-907d-1335a3e1d493">


**after**
<img width="787" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/5465ad35-0e67-4ae5-aa00-2fd2202b6d30">
