### PR TITLE
fix: add timeout to show the toast to wait for subgraph to update stacks

### DIFF
--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -475,7 +475,7 @@ export const Stackbox = () => {
           key={`${fromToken.address}-$${tokenAmount}`}
           onSuccess={() => {
             closeModal(ModalId.CONFIRM_STACK);
-            openModal(ModalId.SUCCESS_STACK_TOAST);
+            setTimeout(() => openModal(ModalId.SUCCESS_STACK_TOAST), 9000); // wait 9s to show toast in order for the subgraph update stacks
           }}
         />
       )}


### PR DESCRIPTION
The issue:
https://linear.app/swaprhq/issue/STK-184/when-success-toast-appears-after-creating-a-stack-and-we-click-it-the

This is an idea to open the discussion.

9 sec timeout I think it makes the trick but not the ideal solution of course but maybe good enough for now.

Thoughts?