### PR TITLE
fix: remove safe from connect wallet list

### DIFF
--- a/packages/app/providers/wagmi-config.ts
+++ b/packages/app/providers/wagmi-config.ts
@@ -50,6 +50,6 @@ const safeConnector = new SafeConnector({
 export const config = createConfig({
   ...defaultConfig,
   connectors: defaultConfig.connectors
-    ? [...defaultConfig.connectors, safeConnector]
+    ? [...defaultConfig.connectors]
     : [safeConnector],
 });


### PR DESCRIPTION
Removes safe from wallet connector

<img width="770" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/9fa92f10-8402-4720-aff4-23449bf46ac5">

Still works on Safe app
<img width="1920" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/e9ff3bf3-09bb-4231-b70d-003bd5a5ea50">

