### PR TITLE
[SWA-189][FIX] - update Stackbox labels to reflect selected tokens info

### DIFF
--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -394,9 +394,7 @@ export const Stackbox = () => {
       <div className="px-5 py-6 space-y-6">
         <div className="space-y-2">
           <TitleText weight="bold" className="text-em-med">
-            {toToken
-              ? `Stack ${toToken?.symbol} every`
-              : "Select a token to receive"}
+            {toToken ? `Stack ${toToken?.symbol} every` : "Stack every"}
           </TitleText>
           <div className="space-y-6">
             <div className="flex space-x-2">

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -394,7 +394,9 @@ export const Stackbox = () => {
       <div className="px-5 py-6 space-y-6">
         <div className="space-y-2">
           <TitleText weight="bold" className="text-em-med">
-            Stack WETH every
+            {toToken
+              ? `Stack ${toToken?.symbol} every`
+              : "Select a token to receive"}
           </TitleText>
           <div className="space-y-6">
             <div className="flex space-x-2">


### PR DESCRIPTION
## Fixes: [SWA-189](https://linear.app/swaprhq/issue/STK-189/update-stackbox-stack-every-label)

# Description
* Update "Stack Every" label in the Stackbox to display the "To receive" token symbol
* Added Stackbox label empty state (for no "To Receive" token selected)


# Visual evidence
![image](https://github.com/SwaprHQ/stackly-ui/assets/21271189/5935a095-9925-4df7-92ca-01ec5809db59)
![image](https://github.com/SwaprHQ/stackly-ui/assets/21271189/d8142cf7-86a5-48d6-b23a-05292741ade9)

# How to test the changes

1) Pull this branch
2) Run the project locally
3) Go to Stackly landing page
4) Connect your wallet
5) Play around selecting different tokens "To receive". Also try selecting and deselecting a strategy to check the empty state.