### PR TITLE
Update: Change words from "worth" -> "swapping" on preview stack

### DIFF
--- a/packages/app/components/stackbox/ConfirmStackModal.tsx
+++ b/packages/app/components/stackbox/ConfirmStackModal.tsx
@@ -191,7 +191,7 @@ export const ConfirmStackModal = ({
           <div>
             <TitleText size={2} className="text-center text-em-low">
               Stacks <span className="text-em-high">{toToken.symbol}</span>,
-              worth{" "}
+              swapping{" "}
               <span className="text-em-high">
                 {amountPerOrder} {fromToken.symbol}
               </span>

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -628,7 +628,7 @@ const StackDetailsTileText = ({
   timeLength,
 }: StackDetailsTileTextProps) => (
   <BodyText size={1}>
-    Stacks <span className="text-em-med">{toTokenSymbol}</span>, worth{" "}
+    Stacks <span className="text-em-med">{toTokenSymbol}</span>, swapping{" "}
     <span className="text-em-med">
       {amountPerOrder} {fromTokenSymbol}
     </span>


### PR DESCRIPTION
On the preview stack I think "worth" is confusing. People asked me what it meant.

After discussing we decided to go with "swapping" as it tells what we do.


**now**
<img width="1091" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/9ae6338e-c492-4dd2-8d62-2c10c5b7e70c">


**before**
<img width="718" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/75529517-8681-4b9a-982d-62a459cc339d">
