### PR TITLE
update: show wrapped tokens instead of native tokens on account

### DIFF
--- a/packages/app/components/ConnectButton.tsx
+++ b/packages/app/components/ConnectButton.tsx
@@ -25,7 +25,7 @@ const CustomConnectButton = ({
   });
 
   const TOKEN_BY_CHAIN: { [chainId: number]: string } = {
-    [ChainId.ETHEREUM]: WETH[1].address,
+    [ChainId.ETHEREUM]: WETH[ChainId.ETHEREUM].address,
     [ChainId.GNOSIS]: WXDAI.address,
   };
 
@@ -35,7 +35,6 @@ const CustomConnectButton = ({
       ? (TOKEN_BY_CHAIN[chain.id] as `0x${string}`)
       : (TOKEN_BY_CHAIN[ChainId.GNOSIS] as `0x${string}`),
   });
-  console.log("balance:", balance);
 
   const truncatedAddress = (size: number) =>
     `${address.slice(0, size)}...${address.slice(

--- a/packages/app/components/ConnectButton.tsx
+++ b/packages/app/components/ConnectButton.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { ConnectKitButton } from "connectkit";
-import { useEnsAvatar, useBalance } from "wagmi";
+import { useEnsAvatar, useBalance, useNetwork } from "wagmi";
 import Image from "next/image";
 import { BodyText, Button, SizeProps } from "@/ui";
 import { useAutoConnect } from "@/hooks";
+import { ChainId, WETH, WXDAI } from "@stackly/sdk";
 
 const CustomConnectButton = ({
   address,
@@ -17,13 +18,24 @@ const CustomConnectButton = ({
   ensName?: string;
   size: SizeProps;
 }) => {
+  const { chain } = useNetwork();
   const { data: avatar } = useEnsAvatar({
     name: ensName,
     chainId: 1,
   });
+
+  const TOKEN_BY_CHAIN: { [chainId: number]: string } = {
+    [ChainId.ETHEREUM]: WETH[1].address,
+    [ChainId.GNOSIS]: WXDAI.address,
+  };
+
   const { data: balance } = useBalance({
     address: address,
+    token: chain
+      ? (TOKEN_BY_CHAIN[chain.id] as `0x${string}`)
+      : (TOKEN_BY_CHAIN[ChainId.GNOSIS] as `0x${string}`),
   });
+  console.log("balance:", balance);
 
   const truncatedAddress = (size: number) =>
     `${address.slice(0, size)}...${address.slice(


### PR DESCRIPTION
Update token balance to show wrapped version, since we don't allow using native tokens.

**Now**
<img width="611" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/5c84a0f6-b991-42dd-b2e7-63979dc9d34d">

<img width="631" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/aeac094c-56ff-400e-8ab8-4154ac1b6d85">
