### PR TITLE
Update: Stackbox limit decimals to 6 when selecting balance options o…

### DIFF
--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -182,7 +182,7 @@ export const Stackbox = () => {
   const [showInsufficentBalanceError, setShowInsufficentBalanceError] =
     useState(false);
 
-  const { data: balance, isRefetching: isRefetchingBalance } = useBalance({
+  const { data: balance } = useBalance({
     address: Boolean(fromToken) ? address : undefined,
     token: fromToken?.address as `0x${string}`,
     chainId: chain?.id,
@@ -375,14 +375,22 @@ export const Stackbox = () => {
   };
 
   const setTokenAmountBasedOnBalance = (divider: number) => {
-    deselectStrategy();
     if (!balance || !fromToken) return;
+    deselectStrategy();
 
     setShowTokenAmountError(false);
     setShowInsufficentBalanceError(false);
-    setTokenAmount(
-      formatUnits(balance.value / BigInt(divider), fromToken.decimals)
+
+    let formattedBalance = formatUnits(
+      balance.value / BigInt(divider),
+      fromToken.decimals
     );
+
+    if (divider != BalanceDivider.MAX) {
+      formattedBalance = Number(formattedBalance).toFixed(6);
+    }
+
+    setTokenAmount(formattedBalance);
   };
 
   const handleStartDateTimeChange = (newDateTime: Date) => {


### PR DESCRIPTION
**Summary**
when selecting 25% and 50% we don't need to show all decimals (now showing 6). 
This simplifies PR aims to simplify it.

**screenshots**
<img width="773" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/07f92912-6264-4bd5-951a-3217c22459d5">

<img width="691" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/97b3b680-6841-4ca0-aac1-e85e677153c3">
