### PR TITLE
[CHORE] - Change from Erroring to Console when fathom site ID is missing

### DIFF
--- a/packages/app/components/FathomAnalytics.tsx
+++ b/packages/app/components/FathomAnalytics.tsx
@@ -16,7 +16,7 @@ const TrackPageView = () => {
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    if (!siteId) throw new Error("Site ID not set, skipping Fathom analytics");
+    if (!siteId) console.log("Site ID not set, skipping Fathom analytics");
   }, []);
 
   useEffect(() => {

--- a/packages/landing/components/FathomAnalytics.tsx
+++ b/packages/landing/components/FathomAnalytics.tsx
@@ -16,7 +16,7 @@ const TrackPageView = () => {
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    if (!siteId) throw new Error("Site ID not set, skipping Fathom analytics");
+    if (!siteId) console.log("Site ID not set, skipping Fathom analytics");
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Fixes: [This comment](https://github.com/SwaprHQ/stackly-ui/pull/137#discussion_r1402140864)

# Description
* Update the way we handle missing FA Site ID to stop the app from halting on dev envs when the FA site ID env var is missing

# How to test the changes

1) Pull this branch
2) Run the project locally
3) Go to Stackly dApp
4) It shouldn't throw an error if the FA Site ID env var is not set