### PR TITLE
[STK-209][FEAT] - Enable select network without a connected wallet

### DIFF
--- a/packages/app/components/ConnectButton.tsx
+++ b/packages/app/components/ConnectButton.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import { ChainId, WETH, WXDAI } from "@stackly/sdk";
 import { ConnectKitButton } from "connectkit";
-import { useEnsAvatar, useBalance, useNetwork } from "wagmi";
 import Image from "next/image";
+import { useAccount, useBalance, useEnsAvatar, useNetwork } from "wagmi";
+
 import { BodyText, Button, SizeProps } from "@/ui";
 import { useAutoConnect } from "@/hooks";
-import { ChainId, WETH, WXDAI } from "@stackly/sdk";
 
 const CustomConnectButton = ({
   address,
@@ -19,9 +20,10 @@ const CustomConnectButton = ({
   size: SizeProps;
 }) => {
   const { chain } = useNetwork();
+  const { isConnected } = useAccount();
   const { data: avatar } = useEnsAvatar({
     name: ensName,
-    chainId: 1,
+    chainId: ChainId.ETHEREUM,
   });
 
   const TOKEN_BY_CHAIN: { [chainId: number]: string } = {
@@ -31,9 +33,10 @@ const CustomConnectButton = ({
 
   const { data: balance } = useBalance({
     address: address,
-    token: chain
-      ? (TOKEN_BY_CHAIN[chain.id] as `0x${string}`)
-      : (TOKEN_BY_CHAIN[ChainId.GNOSIS] as `0x${string}`),
+    token:
+      chain && isConnected
+        ? (TOKEN_BY_CHAIN[chain.id] as `0x${string}`)
+        : (TOKEN_BY_CHAIN[ChainId.GNOSIS] as `0x${string}`),
   });
 
   const truncatedAddress = (size: number) =>

--- a/packages/app/components/ConnectButton.tsx
+++ b/packages/app/components/ConnectButton.tsx
@@ -3,10 +3,11 @@
 import { ChainId, WETH, WXDAI } from "@stackly/sdk";
 import { ConnectKitButton } from "connectkit";
 import Image from "next/image";
-import { useAccount, useBalance, useEnsAvatar, useNetwork } from "wagmi";
+import { useAccount, useBalance, useEnsAvatar } from "wagmi";
 
 import { BodyText, Button, SizeProps } from "@/ui";
 import { useAutoConnect } from "@/hooks";
+import { useNetworkContext } from "@/contexts";
 
 const CustomConnectButton = ({
   address,
@@ -19,7 +20,7 @@ const CustomConnectButton = ({
   ensName?: string;
   size: SizeProps;
 }) => {
-  const { chain } = useNetwork();
+  const { selectedChain } = useNetworkContext();
   const { isConnected } = useAccount();
   const { data: avatar } = useEnsAvatar({
     name: ensName,
@@ -34,8 +35,8 @@ const CustomConnectButton = ({
   const { data: balance } = useBalance({
     address: address,
     token:
-      chain && isConnected
-        ? (TOKEN_BY_CHAIN[chain.id] as `0x${string}`)
+      selectedChain && isConnected
+        ? (TOKEN_BY_CHAIN[selectedChain.id] as `0x${string}`)
         : (TOKEN_BY_CHAIN[ChainId.GNOSIS] as `0x${string}`),
   });
 

--- a/packages/app/components/SelectNetwork.tsx
+++ b/packages/app/components/SelectNetwork.tsx
@@ -30,23 +30,23 @@ export const SelectNetwork = () => {
     []
   );
 
-  const handleOfflineNetworkSwitch = (newChainId: number) => {
+  const handleDisconnectedNetworkSwitch = (newChainId: number) => {
     config.setState((oldState: any) => {
       const { publicClient } = oldState;
       const { chains } = publicClient;
 
-      const offlineChain = chains?.find(
+      const newChain = chains?.find(
         (allowedChain: any) => allowedChain.id === newChainId
       );
 
-      setChainId(offlineChain.id);
-      setSelectedChain(offlineChain);
+      setChainId(newChain.id);
+      setSelectedChain(newChain);
 
       return {
         ...oldState,
         publicClient: {
           ...publicClient,
-          chain: offlineChain,
+          chain: newChain,
         },
       };
     });
@@ -56,7 +56,7 @@ export const SelectNetwork = () => {
     if (isConnected) {
       switchNetwork && switchNetwork(Number(networkId));
     } else {
-      handleOfflineNetworkSwitch(parseInt(networkId));
+      handleDisconnectedNetworkSwitch(parseInt(networkId));
     }
   };
 

--- a/packages/app/components/SelectNetwork.tsx
+++ b/packages/app/components/SelectNetwork.tsx
@@ -9,7 +9,7 @@ import { Button, Icon } from "@/ui";
 import { useNetworkContext, useStackboxFormContext } from "@/contexts";
 
 export const SelectNetwork = () => {
-  const { allowedChains, changeNetwork, selectedChain } = useNetworkContext();
+  const { chains, changeNetwork, selectedChain } = useNetworkContext();
   const { resetFormValues } = useStackboxFormContext();
 
   return (
@@ -48,7 +48,7 @@ export const SelectNetwork = () => {
           leaveTo="opacity-0"
         >
           <Listbox.Options className="absolute z-10 w-auto py-1 mt-1 overflow-auto text-base bg-white shadow-md max-h-60 rounded-2xl focus:outline-none sm:text-sm">
-            {allowedChains?.map(({ id, name }) => (
+            {chains?.map(({ id, name }) => (
               <Listbox.Option
                 key={id}
                 className="relative py-2 pl-4 pr-10 cursor-pointer select-none hover:bg-surface-75"

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -87,11 +87,12 @@ export const Stackbox = () => {
   const { resetFormValues, stackboxFormState } = useStackboxFormContext();
   const { deselectStrategy, selectedStrategy } = useStrategyContext();
   const {
+    tokenList,
     tokenListWithBalances,
     getTokenFromList,
     isLoading: isTokenListLoading,
   } = useTokenListContext();
-  const { address } = useAccount();
+  const { address, isConnected } = useAccount();
 
   const [fromToken, setFromToken] = stackboxFormState.fromTokenState;
   const [toToken, setToToken] = stackboxFormState.toTokenState;
@@ -144,11 +145,20 @@ export const Stackbox = () => {
    */
   useEffect(() => {
     if (selectedStrategy) {
-      const getStrategyToken = (strategyToken: Token) =>
-        tokenListWithBalances?.find(
-          (token) =>
-            token.address.toUpperCase() === strategyToken.address.toUpperCase()
-        ) ?? null;
+      const getStrategyToken = (strategyToken: Token) => {
+        const tokenListToIterate =
+          address && isConnected && tokenListWithBalances
+            ? tokenListWithBalances
+            : tokenList;
+
+        return (
+          tokenListToIterate.find(
+            (token) =>
+              token.address.toUpperCase() ===
+              strategyToken.address.toUpperCase()
+          ) ?? null
+        );
+      };
 
       const strategyEndDate = add(Date.now(), {
         days: selectedStrategy.daysAmount,
@@ -164,8 +174,10 @@ export const Stackbox = () => {
       setEndDateTime(new Date(strategyEndDate));
     }
   }, [
+    address,
     chainId,
     frequency,
+    isConnected,
     selectedStrategy,
     setEndDateTime,
     setFrequency,
@@ -173,6 +185,7 @@ export const Stackbox = () => {
     setStartDateTime,
     setToToken,
     setTokenAmount,
+    tokenList,
     tokenListWithBalances,
   ]);
 

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import {
-  useRef,
-  useState,
-  useEffect,
   AnimationEventHandler,
   useCallback,
+  useEffect,
+  useRef,
+  useState,
 } from "react";
 
 import { add, formatDistance } from "date-fns";
@@ -13,7 +13,7 @@ import { cx } from "class-variance-authority";
 import { formatUnits, parseUnits } from "viem";
 import Link from "next/link";
 import { trackEvent } from "fathom-client";
-import { useAccount, useBalance, useNetwork, useSwitchNetwork } from "wagmi";
+import { useAccount, useBalance } from "wagmi";
 
 import {
   BodyText,
@@ -25,7 +25,6 @@ import {
   TitleText,
   Toast,
 } from "@/ui";
-import { ChainId } from "@stackly/sdk";
 import {
   ConfirmStackModal,
   ConnectButton,
@@ -38,9 +37,9 @@ import {
   ModalId,
   TokenWithBalance,
   useModalContext,
+  useStackboxFormContext,
   useStrategyContext,
   useTokenListContext,
-  useStackboxFormContext,
 } from "@/contexts";
 import {
   FREQUENCY_OPTIONS,
@@ -92,13 +91,6 @@ export const Stackbox = () => {
     getTokenFromList,
     isLoading: isTokenListLoading,
   } = useTokenListContext();
-
-  const { chain } = useNetwork();
-  const { switchNetwork } = useSwitchNetwork({
-    onSuccess(data) {
-      setChainId(data.id);
-    },
-  });
   const { address } = useAccount();
 
   const [fromToken, setFromToken] = stackboxFormState.fromTokenState;
@@ -107,7 +99,7 @@ export const Stackbox = () => {
   const [frequency, setFrequency] = stackboxFormState.frequencyState;
   const [startDateTime, setStartDateTime] = stackboxFormState.startDateState;
   const [endDateTime, setEndDateTime] = stackboxFormState.endDateState;
-  const [chainId, setChainId] = stackboxFormState.chainIdState;
+  const [chainId] = stackboxFormState.chainIdState;
 
   const [showTokenAmountError, setShowTokenAmountError] = useState(false);
   const [showPastEndDateError, setShowPastEndDateError] = useState(false);
@@ -118,9 +110,9 @@ export const Stackbox = () => {
     useState(false);
 
   const { data: balance } = useBalance({
-    address: Boolean(fromToken) ? address : undefined,
+    address: fromToken && address ? address : undefined,
     token: fromToken?.address as `0x${string}`,
-    chainId: chain?.id,
+    chainId,
   });
 
   useEffect(() => {
@@ -145,23 +137,6 @@ export const Stackbox = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isTokenListLoading]);
-
-  useEffect(() => {
-    if (chain) setChainId(chain.id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chain]);
-
-  useEffect(() => {
-    if (
-      chainId &&
-      switchNetwork &&
-      chainId !== chain?.id &&
-      Boolean(ChainId[chainId])
-    ) {
-      switchNetwork(chainId);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [switchNetwork]);
 
   /**
    * Form state handler when we select a
@@ -189,7 +164,7 @@ export const Stackbox = () => {
       setEndDateTime(new Date(strategyEndDate));
     }
   }, [
-    chain,
+    chainId,
     frequency,
     selectedStrategy,
     setEndDateTime,
@@ -545,7 +520,7 @@ export const Stackbox = () => {
                   className="text-primary-800"
                   onClick={() => {
                     deselectStrategy();
-                    resetFormValues();
+                    resetFormValues(chainId);
                   }}
                   size="xs"
                   variant="caption"
@@ -608,7 +583,7 @@ export const Stackbox = () => {
             closeModal(ModalId.CONFIRM_STACK);
             openModal(ModalId.SUCCESS_STACK_TOAST);
             trackEvent(EVENTS.CREATE_FLOW.STACK_SUCCESS);
-            resetFormValues();
+            resetFormValues(chainId);
           }}
         />
       )}

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -37,6 +37,7 @@ import {
   ModalId,
   TokenWithBalance,
   useModalContext,
+  useNetworkContext,
   useStackboxFormContext,
   useStrategyContext,
   useTokenListContext,
@@ -93,6 +94,7 @@ export const Stackbox = () => {
     isLoading: isTokenListLoading,
   } = useTokenListContext();
   const { address, isConnected } = useAccount();
+  const { chainId } = useNetworkContext();
 
   const [fromToken, setFromToken] = stackboxFormState.fromTokenState;
   const [toToken, setToToken] = stackboxFormState.toTokenState;
@@ -100,7 +102,6 @@ export const Stackbox = () => {
   const [frequency, setFrequency] = stackboxFormState.frequencyState;
   const [startDateTime, setStartDateTime] = stackboxFormState.startDateState;
   const [endDateTime, setEndDateTime] = stackboxFormState.endDateState;
-  const [chainId] = stackboxFormState.chainIdState;
 
   const [showTokenAmountError, setShowTokenAmountError] = useState(false);
   const [showPastEndDateError, setShowPastEndDateError] = useState(false);

--- a/packages/app/components/strategies/Strategies.tsx
+++ b/packages/app/components/strategies/Strategies.tsx
@@ -2,15 +2,14 @@
 
 import { Tab } from "@headlessui/react";
 
-import { Strategy, useStackboxFormContext } from "@/contexts";
+import { Strategy, useNetworkContext } from "@/contexts";
 import { tabButtonStyles } from "@/components";
 
 import { StrategyCard } from "./StrategyCard";
 import { STRATEGY_CATEGORIES } from "./constants";
 
 export const Strategies = () => {
-  const { stackboxFormState } = useStackboxFormContext();
-  const [chainId] = stackboxFormState.chainIdState;
+  const { chainId } = useNetworkContext();
 
   const chainStrategies = STRATEGY_CATEGORIES[chainId];
 

--- a/packages/app/components/strategies/Strategies.tsx
+++ b/packages/app/components/strategies/Strategies.tsx
@@ -1,18 +1,16 @@
 "use client";
 
 import { Tab } from "@headlessui/react";
-import { useNetwork } from "wagmi";
 
-import { ChainId } from "@stackly/sdk";
-import { Strategy } from "@/contexts";
+import { Strategy, useStackboxFormContext } from "@/contexts";
 import { tabButtonStyles } from "@/components";
 
 import { StrategyCard } from "./StrategyCard";
 import { STRATEGY_CATEGORIES } from "./constants";
 
 export const Strategies = () => {
-  const { chain } = useNetwork();
-  const chainId = chain?.id ?? ChainId.GNOSIS;
+  const { stackboxFormState } = useStackboxFormContext();
+  const [chainId] = stackboxFormState.chainIdState;
 
   const chainStrategies = STRATEGY_CATEGORIES[chainId];
 

--- a/packages/app/components/strategies/StrategyCard.tsx
+++ b/packages/app/components/strategies/StrategyCard.tsx
@@ -7,6 +7,7 @@ import { Button, CaptionText, Icon } from "@/ui";
 import { EVENTS } from "@/analytics";
 import {
   Strategy,
+  useNetworkContext,
   useStackboxFormContext,
   useStrategyContext,
 } from "@/contexts";
@@ -19,9 +20,9 @@ interface StrategyCardProps {
 }
 
 export const StrategyCard = ({ strategy }: StrategyCardProps) => {
-  const { stackboxFormState, resetFormValues } = useStackboxFormContext();
+  const { resetFormValues } = useStackboxFormContext();
   const { selectedStrategy, setSelectedStrategy } = useStrategyContext();
-  const [chainId] = stackboxFormState.chainIdState;
+  const { chainId } = useNetworkContext();
 
   const { buyToken, sellToken } = strategy;
 

--- a/packages/app/components/strategies/StrategyCard.tsx
+++ b/packages/app/components/strategies/StrategyCard.tsx
@@ -10,7 +10,7 @@ import {
   useStackboxFormContext,
   useStrategyContext,
 } from "@/contexts";
-import { TokenLogoPair } from "@/components/TokenLogoPair";
+import { TokenLogoPair } from "@/components";
 
 import { FREQUENCY_LABEL } from "./constants";
 
@@ -19,8 +19,9 @@ interface StrategyCardProps {
 }
 
 export const StrategyCard = ({ strategy }: StrategyCardProps) => {
-  const { resetFormValues } = useStackboxFormContext();
+  const { stackboxFormState, resetFormValues } = useStackboxFormContext();
   const { selectedStrategy, setSelectedStrategy } = useStrategyContext();
+  const [chainId] = stackboxFormState.chainIdState;
 
   const { buyToken, sellToken } = strategy;
 
@@ -45,7 +46,7 @@ export const StrategyCard = ({ strategy }: StrategyCardProps) => {
       )}
       onClick={() => {
         setSelectedStrategy(isSelected ? null : strategy);
-        !isSelected ? trackEvent(cardClickEventName) : resetFormValues();
+        !isSelected ? trackEvent(cardClickEventName) : resetFormValues(chainId);
       }}
     >
       <div className="flex">

--- a/packages/app/components/token-picker/TokenPicker.tsx
+++ b/packages/app/components/token-picker/TokenPicker.tsx
@@ -2,6 +2,8 @@
 
 import { ChangeEvent, RefObject, forwardRef, useEffect, useState } from "react";
 
+import { useAccount } from "wagmi";
+
 import {
   BodyText,
   Button,
@@ -16,7 +18,7 @@ import { EmptyStateTokenPickerImg } from "@/public/assets";
 import { TokenIcon } from "@/components";
 import {
   TokenWithBalance,
-  useStackboxFormContext,
+  useNetworkContext,
   useTokenListContext,
 } from "@/contexts";
 import { formatTokenValue } from "@/utils/token";
@@ -43,8 +45,8 @@ export const TokenPicker = ({
   onTokenSelect,
 }: TokenPickerProps) => {
   const { tokenList, tokenListWithBalances } = useTokenListContext();
-  const { stackboxFormState } = useStackboxFormContext();
-  const [chainId] = stackboxFormState.chainIdState;
+  const { chainId } = useNetworkContext();
+  const { isConnected } = useAccount();
 
   const [tokenSearchQuery, setTokenSearchQuery] = useState("");
   const [commonTokens, setCommonTokens] = useState<TokenFromTokenlist[]>(
@@ -113,9 +115,7 @@ export const TokenPicker = ({
         <TokenList
           onClearSearch={tokenListSearchCleanup}
           onTokenSelect={handleTokenSelect}
-          tokenList={
-            tokenListWithBalances?.length ? tokenListWithBalances : tokenList
-          }
+          tokenList={isConnected ? tokenListWithBalances : tokenList}
           tokenSearchQuery={tokenSearchQuery}
         />
       </ModalContent>

--- a/packages/app/components/token-picker/TokenPicker.tsx
+++ b/packages/app/components/token-picker/TokenPicker.tsx
@@ -2,8 +2,6 @@
 
 import { ChangeEvent, RefObject, forwardRef, useEffect, useState } from "react";
 
-import { ChainId } from "@stackly/sdk";
-
 import {
   BodyText,
   Button,
@@ -44,15 +42,15 @@ export const TokenPicker = ({
   isOpen,
   onTokenSelect,
 }: TokenPickerProps) => {
-  const [tokenSearchQuery, setTokenSearchQuery] = useState("");
-  const [commonTokens, setCommonTokens] = useState<TokenFromTokenlist[]>(
-    TOKEN_PICKER_COMMON_TOKENS[ChainId.GNOSIS]
-  );
-  const [debouncedQuery, setDebouncedQuery] = useState(tokenSearchQuery);
-
   const { tokenList, tokenListWithBalances } = useTokenListContext();
   const { stackboxFormState } = useStackboxFormContext();
   const [chainId] = stackboxFormState.chainIdState;
+
+  const [tokenSearchQuery, setTokenSearchQuery] = useState("");
+  const [commonTokens, setCommonTokens] = useState<TokenFromTokenlist[]>(
+    TOKEN_PICKER_COMMON_TOKENS[chainId]
+  );
+  const [debouncedQuery, setDebouncedQuery] = useState(tokenSearchQuery);
 
   const tokenListSearchCleanup = () => {
     setDebouncedQuery("");

--- a/packages/app/components/token-picker/TokenPicker.tsx
+++ b/packages/app/components/token-picker/TokenPicker.tsx
@@ -2,6 +2,8 @@
 
 import { ChangeEvent, RefObject, forwardRef, useEffect, useState } from "react";
 
+import { ChainId } from "@stackly/sdk";
+
 import {
   BodyText,
   Button,
@@ -14,12 +16,15 @@ import {
 } from "@/ui";
 import { EmptyStateTokenPickerImg } from "@/public/assets";
 import { TokenIcon } from "@/components";
-import { TOKEN_PICKER_COMMON_TOKENS } from "./constants";
-import { TokenWithBalance, useTokenListContext } from "@/contexts";
+import {
+  TokenWithBalance,
+  useStackboxFormContext,
+  useTokenListContext,
+} from "@/contexts";
 import { formatTokenValue } from "@/utils/token";
 import { TokenFromTokenlist } from "@/models/token";
-import { useNetwork } from "wagmi";
-import { ChainId } from "@stackly/sdk";
+
+import { TOKEN_PICKER_COMMON_TOKENS } from "./constants";
 
 const HALF_SECOND = 500;
 
@@ -46,7 +51,8 @@ export const TokenPicker = ({
   const [debouncedQuery, setDebouncedQuery] = useState(tokenSearchQuery);
 
   const { tokenList, tokenListWithBalances } = useTokenListContext();
-  const { chain } = useNetwork();
+  const { stackboxFormState } = useStackboxFormContext();
+  const [chainId] = stackboxFormState.chainIdState;
 
   const tokenListSearchCleanup = () => {
     setDebouncedQuery("");
@@ -84,8 +90,8 @@ export const TokenPicker = ({
    * Updates the token common tokens on chain switch
    */
   useEffect(() => {
-    if (chain?.id) setCommonTokens(TOKEN_PICKER_COMMON_TOKENS[chain.id]);
-  }, [chain]);
+    if (chainId) setCommonTokens(TOKEN_PICKER_COMMON_TOKENS[chainId]);
+  }, [chainId]);
 
   return (
     <Modal

--- a/packages/app/contexts/NetworkContext.tsx
+++ b/packages/app/contexts/NetworkContext.tsx
@@ -14,7 +14,7 @@ import { ChainId } from "@stackly/sdk";
 import { gnosis } from "wagmi/chains";
 import { useAccount, useNetwork, useSwitchNetwork } from "wagmi";
 
-import { config } from "@/providers";
+import { config } from "@/providers/wagmi-config";
 import { parseAsInteger, useQueryState } from "next-usequerystate";
 import { getIsValidChainId } from "@/utils";
 

--- a/packages/app/contexts/NetworkContext.tsx
+++ b/packages/app/contexts/NetworkContext.tsx
@@ -87,7 +87,7 @@ export const NetworkContextProvider = ({
       setSelectedChain(validChain as WagmiChain);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chainId]);
+  }, [chainId, selectedChain]);
 
   useEffect(() => {
     if (isConnected && chain) setSelectedChain(chain);

--- a/packages/app/contexts/NetworkContext.tsx
+++ b/packages/app/contexts/NetworkContext.tsx
@@ -83,7 +83,7 @@ export const NetworkContextProvider = ({
       const validChainId = isValidChainId ? chainId : ChainId.GNOSIS;
       const validChain = chains.find((chain) => chain.id === validChainId);
 
-      setSelectedChain(validChain ?? gnosis);
+      setSelectedChain(validChain as WagmiChain);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chainId]);

--- a/packages/app/contexts/NetworkContext.tsx
+++ b/packages/app/contexts/NetworkContext.tsx
@@ -27,7 +27,7 @@ const throwNetworkContextError = () => {
 };
 
 interface NetworkContextProps {
-  allowedChains?: WagmiChain[];
+  chains?: WagmiChain[];
   chainId: ChainId;
   changeNetwork: (newChainId: string) => void;
   selectedChain: WagmiChain;
@@ -56,9 +56,7 @@ export const NetworkContextProvider = ({
     parseAsInteger.withDefault(ChainId.GNOSIS)
   );
   const [selectedChain, setSelectedChain] = useState<WagmiChain>(gnosis);
-  const [allowedChains, setAllowedChains] = useState<WagmiChain[] | undefined>(
-    []
-  );
+  const [chains, setChains] = useState<WagmiChain[] | undefined>([]);
 
   const { switchNetwork } = useSwitchNetwork({
     onSuccess(data) {
@@ -67,10 +65,13 @@ export const NetworkContextProvider = ({
   });
 
   useEffect(() => {
-    const { chains } = config.getPublicClient();
+    const { chains: wagmiChains } = config.getPublicClient();
 
-    if (!chainId) setChainId(ChainId.GNOSIS);
-    if (chains) setAllowedChains(chains);
+    if (!chainId) {
+      setChainId(ChainId.GNOSIS);
+      setSelectedChain(gnosis);
+    }
+    if (chains) setChains(wagmiChains);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -98,9 +99,7 @@ export const NetworkContextProvider = ({
         const { publicClient } = oldState;
         const { chains } = publicClient;
 
-        const newChain = chains?.find(
-          (allowedChain: any) => allowedChain.id === newChainId
-        );
+        const newChain = chains?.find((chain: any) => chain.id === newChainId);
 
         setChainId(newChain.id);
         setSelectedChain(newChain);
@@ -124,20 +123,13 @@ export const NetworkContextProvider = ({
     };
 
     return {
-      allowedChains,
+      chains,
       chainId,
       changeNetwork,
       selectedChain,
       setChainId,
     };
-  }, [
-    allowedChains,
-    chainId,
-    isConnected,
-    selectedChain,
-    setChainId,
-    switchNetwork,
-  ]);
+  }, [chains, chainId, isConnected, selectedChain, setChainId, switchNetwork]);
 
   return (
     <NetworkContext.Provider value={networkContext}>

--- a/packages/app/contexts/NetworkContext.tsx
+++ b/packages/app/contexts/NetworkContext.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import {
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import type { Chain } from "viem/chains";
+import { ChainId } from "@stackly/sdk";
+import { gnosis } from "wagmi/chains";
+import { useAccount, useNetwork, useSwitchNetwork } from "wagmi";
+
+import { config } from "@/providers";
+import { parseAsInteger, useQueryState } from "next-usequerystate";
+import { getIsValidChainId } from "@/utils";
+
+interface WagmiChain extends Chain {
+  unsupported?: boolean;
+}
+
+const throwNetworkContextError = () => {
+  throw new Error("No NetworkContext available");
+};
+
+interface NetworkContextProps {
+  allowedChains?: WagmiChain[];
+  chainId: ChainId;
+  changeNetwork: (newChainId: string) => void;
+  selectedChain: WagmiChain;
+  setChainId: React.Dispatch<React.SetStateAction<ChainId | null>>;
+}
+
+const NetworkContext = createContext<NetworkContextProps>({
+  chainId: ChainId.GNOSIS,
+  changeNetwork: throwNetworkContextError,
+  selectedChain: gnosis,
+  setChainId: throwNetworkContextError,
+});
+
+interface NetworkContextProviderProps {
+  children: ReactNode;
+}
+
+export const NetworkContextProvider = ({
+  children,
+}: NetworkContextProviderProps) => {
+  const { chain } = useNetwork();
+  const { isConnected } = useAccount();
+
+  const [chainId, setChainId] = useQueryState(
+    "chainId",
+    parseAsInteger.withDefault(ChainId.GNOSIS)
+  );
+  const [selectedChain, setSelectedChain] = useState<WagmiChain>(gnosis);
+  const [allowedChains, setAllowedChains] = useState<WagmiChain[] | undefined>(
+    []
+  );
+
+  const { switchNetwork } = useSwitchNetwork({
+    onSuccess(data) {
+      setChainId(data.id);
+    },
+  });
+
+  useEffect(() => {
+    const { chains } = config.getPublicClient();
+
+    if (!chainId) setChainId(ChainId.GNOSIS);
+    if (chains) setAllowedChains(chains);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const { chains } = config.getPublicClient();
+    const isValidChainId = getIsValidChainId(chainId);
+
+    if (!isValidChainId) setChainId(ChainId.GNOSIS);
+    if (chains) {
+      const validChainId = isValidChainId ? chainId : ChainId.GNOSIS;
+      const validChain = chains.find((chain) => chain.id === validChainId);
+
+      setSelectedChain(validChain ?? gnosis);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chainId]);
+
+  useEffect(() => {
+    if (isConnected && chain) setSelectedChain(chain);
+  }, [chain, isConnected]);
+
+  const networkContext = useMemo(() => {
+    const handleDisconnectedNetworkSwitch = (newChainId: number) => {
+      config.setState((oldState: any) => {
+        const { publicClient } = oldState;
+        const { chains } = publicClient;
+
+        const newChain = chains?.find(
+          (allowedChain: any) => allowedChain.id === newChainId
+        );
+
+        setChainId(newChain.id);
+        setSelectedChain(newChain);
+
+        return {
+          ...oldState,
+          publicClient: {
+            ...publicClient,
+            chain: newChain,
+          },
+        };
+      });
+    };
+
+    const changeNetwork = (networkId: string) => {
+      if (isConnected) {
+        switchNetwork && switchNetwork(Number(networkId));
+      } else {
+        handleDisconnectedNetworkSwitch(parseInt(networkId));
+      }
+    };
+
+    return {
+      allowedChains,
+      chainId,
+      changeNetwork,
+      selectedChain,
+      setChainId,
+    };
+  }, [
+    allowedChains,
+    chainId,
+    isConnected,
+    selectedChain,
+    setChainId,
+    switchNetwork,
+  ]);
+
+  return (
+    <NetworkContext.Provider value={networkContext}>
+      {children}
+    </NetworkContext.Provider>
+  );
+};
+
+export const useNetworkContext = () => useContext(NetworkContext);

--- a/packages/app/contexts/NetworkContext.tsx
+++ b/packages/app/contexts/NetworkContext.tsx
@@ -67,13 +67,23 @@ export const NetworkContextProvider = ({
   useEffect(() => {
     const { chains: wagmiChains } = config.getPublicClient();
 
+    if (chains) setChains(wagmiChains);
     if (!chainId) {
       setChainId(ChainId.GNOSIS);
       setSelectedChain(gnosis);
     }
-    if (chains) setChains(wagmiChains);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    const { chains: wagmiChains } = config.getPublicClient();
+    const chainFromParams = wagmiChains?.find((chain) => chain.id === chainId);
+
+    if (isConnected && chain?.id !== chainFromParams?.id && switchNetwork)
+      switchNetwork?.(chainId);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [switchNetwork]);
 
   useEffect(() => {
     const { chains } = config.getPublicClient();

--- a/packages/app/contexts/StackboxFormContext.tsx
+++ b/packages/app/contexts/StackboxFormContext.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { createContext, useContext, ReactNode, useMemo } from "react";
+import { ReactNode, createContext, useContext, useMemo } from "react";
 
 import { ChainId } from "@stackly/sdk";
 import {
   createParser,
-  parseAsInteger,
   parseAsString,
   parseAsStringEnum,
   parseAsTimestamp,
@@ -16,6 +15,7 @@ import { DEFAULT_TOKENS_BY_CHAIN, getIsValidChainId } from "@/utils";
 import { FREQUENCY_OPTIONS } from "@/models/stack";
 import {
   TokenWithBalance,
+  useNetworkContext,
   useStrategyContext,
   useTokenListContext,
 } from "@/contexts";
@@ -67,13 +67,9 @@ interface StackboxFormContextProviderProps {
 export const StackboxFormContextProvider = ({
   children,
 }: StackboxFormContextProviderProps) => {
+  const { chainId } = useNetworkContext();
   const { deselectStrategy } = useStrategyContext();
   const { getTokenFromList } = useTokenListContext();
-
-  const [chainId, setContextChainId] = useQueryState(
-    "chainId",
-    parseAsInteger.withDefault(ChainId.GNOSIS)
-  );
 
   const getDefaultParsedToken = (tokenDirection: "to" | "from") => {
     const validChainId = getIsValidChainId(chainId) ? chainId : ChainId.GNOSIS;
@@ -124,11 +120,6 @@ export const StackboxFormContextProvider = ({
       setFrequency(FREQUENCY_OPTIONS.hour);
       setStartDateTime(new Date(Date.now()));
       setEndDateTime(new Date(endDateByFrequency[frequency]));
-      setContextChainId(validChainId);
-    };
-
-    const setChainId = (newChainId: ChainId) => {
-      resetFormValues(newChainId);
     };
 
     const stackboxFormState = {
@@ -138,7 +129,6 @@ export const StackboxFormContextProvider = ({
       frequencyState: [frequency, setFrequency],
       startDateState: [startDateTime, setStartDateTime],
       endDateState: [endDateTime, setEndDateTime],
-      chainIdState: [chainId, setChainId],
     };
 
     return {
@@ -146,12 +136,10 @@ export const StackboxFormContextProvider = ({
       stackboxFormState,
     };
   }, [
-    chainId,
     deselectStrategy,
     endDateTime,
     frequency,
     fromToken,
-    setContextChainId,
     setEndDateTime,
     setFrequency,
     setFromToken,

--- a/packages/app/contexts/TokenListContext.tsx
+++ b/packages/app/contexts/TokenListContext.tsx
@@ -9,16 +9,19 @@ import {
   useMemo,
   useState,
 } from "react";
-import { useAccount, useNetwork } from "wagmi";
-import { formatUnits, hexToBigInt } from "viem";
 
 import { ChainId, MULTICALL_ADDRESS } from "@stackly/sdk";
 import { Erc20Abi, MulticallAbi } from "@stackly/sdk/abis";
+import { ethers } from "ethers";
+import { formatUnits, hexToBigInt } from "viem";
+import { useAccount } from "wagmi";
+
+import { RPC_LIST } from "@/constants";
+import { TokenFromTokenlist } from "@/models";
+
 import defaultGnosisTokenlist from "public/assets/blockchains/gnosis/tokenlist.json";
 import defaultEthereumTokenlist from "public/assets/blockchains/ethereum/tokenlist.json";
-import { TokenFromTokenlist } from "@/models/token/types";
-import { ethers } from "ethers";
-import { RPC_LIST } from "@/constants";
+import { useStackboxFormContext } from "./StackboxFormContext";
 
 export interface TokenWithBalance extends TokenFromTokenlist {
   balance?: string;
@@ -74,23 +77,23 @@ const mergeTokenlists = (
 };
 
 export const TokenListProvider = ({ children }: PropsWithChildren) => {
+  const { address } = useAccount();
+  const { stackboxFormState } = useStackboxFormContext();
+  const [chainId] = stackboxFormState.chainIdState;
+
   const [tokenList, setTokenList] = useState<TokenFromTokenlist[]>(
     defaultGnosisTokenlist
   );
   const [tokenListWithBalances, setTokenListWithBalances] =
     useState<TokenWithBalance[]>();
   const [isLoading, setIsLoading] = useState(true);
-  const { chain } = useNetwork();
-  const { address } = useAccount();
 
-  const chainId = chain?.id ?? ChainId.GNOSIS;
-
-  const defaultTokenList = chain
-    ? DEFAULT_TOKEN_LIST_BY_CHAIN[chain.id]
+  const defaultTokenList = chainId
+    ? DEFAULT_TOKEN_LIST_BY_CHAIN[chainId]
     : DEFAULT_TOKEN_LIST_BY_CHAIN[ChainId.GNOSIS];
 
-  const fetchTokenlistURLS = chain
-    ? TOKEN_LISTS_BY_CHAIN_URL[chain.id]
+  const fetchTokenlistURLS = chainId
+    ? TOKEN_LISTS_BY_CHAIN_URL[chainId]
     : TOKEN_LISTS_BY_CHAIN_URL[ChainId.GNOSIS];
 
   const callArray = useMemo(() => {

--- a/packages/app/contexts/TokenListContext.tsx
+++ b/packages/app/contexts/TokenListContext.tsx
@@ -21,7 +21,7 @@ import { TokenFromTokenlist } from "@/models";
 
 import defaultGnosisTokenlist from "public/assets/blockchains/gnosis/tokenlist.json";
 import defaultEthereumTokenlist from "public/assets/blockchains/ethereum/tokenlist.json";
-import { useStackboxFormContext } from "./StackboxFormContext";
+import { useNetworkContext } from "./NetworkContext";
 
 export interface TokenWithBalance extends TokenFromTokenlist {
   balance?: string;
@@ -78,8 +78,7 @@ const mergeTokenlists = (
 
 export const TokenListProvider = ({ children }: PropsWithChildren) => {
   const { address } = useAccount();
-  const { stackboxFormState } = useStackboxFormContext();
-  const [chainId] = stackboxFormState.chainIdState;
+  const { chainId } = useNetworkContext();
 
   const [tokenList, setTokenList] = useState<TokenFromTokenlist[]>(
     defaultGnosisTokenlist
@@ -88,13 +87,8 @@ export const TokenListProvider = ({ children }: PropsWithChildren) => {
     useState<TokenWithBalance[]>();
   const [isLoading, setIsLoading] = useState(true);
 
-  const defaultTokenList = chainId
-    ? DEFAULT_TOKEN_LIST_BY_CHAIN[chainId]
-    : DEFAULT_TOKEN_LIST_BY_CHAIN[ChainId.GNOSIS];
-
-  const fetchTokenlistURLS = chainId
-    ? TOKEN_LISTS_BY_CHAIN_URL[chainId]
-    : TOKEN_LISTS_BY_CHAIN_URL[ChainId.GNOSIS];
+  const defaultTokenList = DEFAULT_TOKEN_LIST_BY_CHAIN[chainId];
+  const fetchTokenlistUrls = TOKEN_LISTS_BY_CHAIN_URL[chainId];
 
   const callArray = useMemo(() => {
     const erc20Interface = new ethers.utils.Interface(Erc20Abi);
@@ -161,7 +155,7 @@ export const TokenListProvider = ({ children }: PropsWithChildren) => {
     }
 
     Promise.allSettled(
-      fetchTokenlistURLS.map((list) => getTokenListData(list))
+      fetchTokenlistUrls.map((list) => getTokenListData(list))
     ).then((results) => {
       results.forEach((result) => {
         if (result.status === "fulfilled") {
@@ -181,7 +175,7 @@ export const TokenListProvider = ({ children }: PropsWithChildren) => {
       );
       setIsLoading(false);
     });
-  }, [chainId, defaultTokenList, fetchTokenlistURLS]);
+  }, [chainId, defaultTokenList, fetchTokenlistUrls]);
 
   useEffect(() => {
     setupTokenList();

--- a/packages/app/contexts/index.ts
+++ b/packages/app/contexts/index.ts
@@ -1,4 +1,5 @@
 export * from "./ModalContext";
+export * from "./NetworkContext";
 export * from "./StackboxFormContext";
 export * from "./StrategyContext";
 export * from "./TokenListContext";

--- a/packages/app/providers/Providers.tsx
+++ b/packages/app/providers/Providers.tsx
@@ -17,15 +17,13 @@ export const Providers = ({ children }: PropsWithChildren) => {
   return (
     <WagmiConfig config={config}>
       <ConnectKitProvider mode="light">
-        <TokenListProvider>
-          <ModalContextProvider>
-            <StrategyContextProvider>
-              <StackboxFormContextProvider>
-                {children}
-              </StackboxFormContextProvider>
-            </StrategyContextProvider>
-          </ModalContextProvider>
-        </TokenListProvider>
+        <ModalContextProvider>
+          <StrategyContextProvider>
+            <StackboxFormContextProvider>
+              <TokenListProvider>{children}</TokenListProvider>
+            </StackboxFormContextProvider>
+          </StrategyContextProvider>
+        </ModalContextProvider>
       </ConnectKitProvider>
     </WagmiConfig>
   );

--- a/packages/app/providers/Providers.tsx
+++ b/packages/app/providers/Providers.tsx
@@ -8,6 +8,7 @@ import { WagmiConfig } from "wagmi";
 import { config } from "./wagmi-config";
 import {
   ModalContextProvider,
+  NetworkContextProvider,
   StackboxFormContextProvider,
   StrategyContextProvider,
   TokenListProvider,
@@ -17,13 +18,17 @@ export const Providers = ({ children }: PropsWithChildren) => {
   return (
     <WagmiConfig config={config}>
       <ConnectKitProvider mode="light">
-        <ModalContextProvider>
-          <StrategyContextProvider>
-            <StackboxFormContextProvider>
-              <TokenListProvider>{children}</TokenListProvider>
-            </StackboxFormContextProvider>
-          </StrategyContextProvider>
-        </ModalContextProvider>
+        <NetworkContextProvider>
+          <TokenListProvider>
+            <ModalContextProvider>
+              <StrategyContextProvider>
+                <StackboxFormContextProvider>
+                  {children}
+                </StackboxFormContextProvider>
+              </StrategyContextProvider>
+            </ModalContextProvider>
+          </TokenListProvider>
+        </NetworkContextProvider>
       </ConnectKitProvider>
     </WagmiConfig>
   );

--- a/packages/app/providers/index.ts
+++ b/packages/app/providers/index.ts
@@ -1,1 +1,2 @@
 export * from "./Providers";
+export * from "./wagmi-config";

--- a/packages/app/providers/index.ts
+++ b/packages/app/providers/index.ts
@@ -1,2 +1,1 @@
 export * from "./Providers";
-export * from "./wagmi-config";

--- a/packages/app/providers/wagmi-config.ts
+++ b/packages/app/providers/wagmi-config.ts
@@ -1,9 +1,12 @@
+"use client";
+
+import { ChainId } from "@stackly/sdk";
+import { SafeConnector } from "wagmi/connectors/safe";
 import { configureChains, createConfig } from "wagmi";
 import { getDefaultConfig } from "connectkit";
 import { gnosis, mainnet } from "wagmi/chains";
 import { jsonRpcProvider } from "wagmi/providers/jsonRpc";
-import { ChainId } from "@stackly/sdk";
-import { SafeConnector } from "wagmi/connectors/safe";
+
 import { RPC_LIST } from "@/constants";
 
 const chainJsonRpc: Record<number, { http: string }> = {

--- a/packages/app/providers/wagmi-config.ts
+++ b/packages/app/providers/wagmi-config.ts
@@ -1,5 +1,3 @@
-"use client";
-
 import { ChainId } from "@stackly/sdk";
 import { SafeConnector } from "wagmi/connectors/safe";
 import { configureChains, createConfig } from "wagmi";

--- a/packages/app/utils/chain.ts
+++ b/packages/app/utils/chain.ts
@@ -1,4 +1,4 @@
 import { ChainId } from "@stackly/sdk";
 
-export const getIsValidChainId = (newChainId: number) =>
+export const getIsValidChainId = (newChainId: number): Boolean =>
   Object.values(ChainId).some((chainId) => chainId === newChainId);

--- a/packages/app/utils/chain.ts
+++ b/packages/app/utils/chain.ts
@@ -1,0 +1,4 @@
+import { ChainId } from "@stackly/sdk";
+
+export const getIsValidChainId = (newChainId: number) =>
+  Object.values(ChainId).some((chainId) => chainId === newChainId);

--- a/packages/app/utils/index.ts
+++ b/packages/app/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./chain";
 export * from "./constants";
 export * from "./datetime";
 export * from "./ethers";


### PR DESCRIPTION
## Fixes: [STK-209](https://linear.app/swaprhq/issue/STK-209/enable-select-network-without-connected-wallet)

# Description
* Moved some code out from the Stackbox and into SelectNetwork (concern separation)
* Created custom code to handle the Chain switch as app state 
* Updated the way we consume the chain switch where it's needed

# Visual evidence
![image](https://github.com/SwaprHQ/stackly-ui/assets/21271189/e3150862-71ff-4550-b829-d5078171035b)
![image](https://github.com/SwaprHQ/stackly-ui/assets/21271189/ca46fb0d-0e11-4d69-93a6-3e440bbee7f1)

# How to test the changes

1) Pull this branch
2) Run the project locally
3) Go to Stackly dApp
4) Connect your wallet
5) You should be able to change the selected chain either by connecting the wallet or with your wallet disconnected from the dApp. The Stackbox, Strategies, and TokenPicker should display relevant information either way.