### PR TITLE
[STK-188][STYLES] - Center dApp background image and update date pickers spacing

### DIFF
--- a/packages/app/app/layout.tsx
+++ b/packages/app/app/layout.tsx
@@ -49,7 +49,7 @@ const siteId = process.env.NEXT_PUBLIC_FATHOM_SITE_ID;
 export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en" className={stabilGrotesk.variable}>
-      <body className="font-sans bg-fixed bg-surface-25 bg-auto-100 bg-matrix-and-green-gradient text-em-high">
+      <body className="font-sans bg-fixed bg-no-repeat bg-100-100 bg-surface-25 bg-matrix-and-green-gradient text-em-high">
         <FathomAnalytics />
         <Providers>
           <Navbar />

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -447,7 +447,7 @@ export const Stackbox = () => {
           <TitleText weight="bold" className="text-em-med">
             {toToken ? `Stack ${toToken?.symbol} every` : "Stack every"}
           </TitleText>
-          <div className="space-y-6">
+          <div className="space-y-4 lg:space-y-6">
             <div className="flex space-x-2">
               {frequencyOptions.map(({ option, name }) => {
                 const isSelected = frequency === option;
@@ -475,7 +475,7 @@ export const Stackbox = () => {
             </div>
             <div className="space-y-1">
               <div className="flex flex-col border divide-y md:divide-y-0 md:flex-row rounded-2xl border-surface-50 md:divide-x divide-surface-50">
-                <div className="flex flex-col w-full p-3 space-y-2 hover:bg-surface-25">
+                <div className="flex flex-col w-full pl-4 pr-3 py-2 lg:py-3 space-y-2 hover:bg-surface-25">
                   <BodyText size={2}>Starting from</BodyText>
                   <DatePicker
                     dateTime={startDateTime}

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -486,7 +486,7 @@ export const Stackbox = () => {
                 </div>
                 <div
                   className={cx(
-                    "flex flex-col w-full p-3 space-y-2 hover:bg-surface-25",
+                    "flex flex-col w-full pl-4 pr-3 py-2 lg:py-3 space-y-2 hover:bg-surface-25",
                     {
                       "!border !border-danger-200 !rounded-r-2xl":
                         showPastEndDateError,

--- a/packages/app/tailwind.config.js
+++ b/packages/app/tailwind.config.js
@@ -80,7 +80,7 @@ module.exports = {
       current: "currentColor",
     },
     backgroundSize: {
-      "auto-100": "auto 100%",
+      "100-100": "100% 100%",
     },
     extend: {
       opacity: {

--- a/packages/app/ui/buttons/RadioButton.tsx
+++ b/packages/app/ui/buttons/RadioButton.tsx
@@ -8,7 +8,7 @@ interface RadioButtonProps extends React.InputHTMLAttributes<HTMLInputElement> {
 
 export const radioButtonStyles = cva(
   [
-    "flex items-center justify-center rounded-full px-3 py-2 space-x-1.5",
+    "flex items-center justify-center rounded-full px-3.5 py-2 space-x-1.5",
     "cursor-pointer select-none font-medium text-xs",
     "active:ring-4",
     "disabled:bg-surface-75 disabled:text-em-disabled disabled:cursor-not-allowed disabled:ring-0",


### PR DESCRIPTION
## Fixes: [STK-188](https://linear.app/swaprhq/issue/STK-188/cosmetic-fixes)

# Description
* Moved some code out from the Stackbox and into SelectNetwork (concern separation)
* Created custom code to handle the Chain switch as app state 
* Updated the way we consume the chain switch where it's needed

# Visual evidence
## Date picker Spacing, Figma File:
![image](https://github.com/SwaprHQ/stackly-ui/assets/21271189/7a46358d-9c6f-47d1-8edd-17d8c1d704f2)
![image](https://github.com/SwaprHQ/stackly-ui/assets/21271189/95041412-f0f9-48ee-bf31-ea2c80782c48)

## Date picker Spacing, Old Version:
![image](https://github.com/SwaprHQ/stackly-ui/assets/21271189/15437a4a-2e7a-4f8a-95f4-fcaf9c34f92d)

## Date picker Spacing, New Version:
![image](https://github.com/SwaprHQ/stackly-ui/assets/21271189/bd91e372-587d-4aa2-953f-e6fc74c8776c)

## Background image horizontal centered, Old Version:
![image](https://github.com/SwaprHQ/stackly-ui/assets/21271189/9f40cfdf-42ad-4a94-935d-f02616001939)

## Background image horizontal centered, New Version:
![image](https://github.com/SwaprHQ/stackly-ui/assets/21271189/216f7eb0-d8cd-4974-b711-4e62f33864f2)


# How to test the changes

1) Pull this branch
2) Run the project locally
3) Go to Stackly dApp
4) Connect your wallet
5) 
    a. The matrix background image should be both horizontally and vertically centered
    b. The container for both date pickers should have the correct spacing for both mobile and desktop