### PR TITLE
[STK-216][FIX] - Wrong AVG bought token price on executed orders table

### DIFF
--- a/packages/app/components/stack-modal/StackOrdersTable.tsx
+++ b/packages/app/components/stack-modal/StackOrdersTable.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
+
 import Link from "next/link";
-import { cowExplorerUrl } from "@/models/cow-order";
-import { orderPairSymbolsText } from "@/models/order";
-import { StackOrder, StackOrderProps } from "@/models/stack-order";
+import { Order as CowOrder } from "@cowprotocol/cow-sdk";
+
+import { addressShortner, convertedAmount, formatDate } from "@/utils";
 import {
   BodyText,
   Icon,
@@ -14,10 +15,13 @@ import {
   TableHeader,
   TableRow,
 } from "@/ui";
-import { formatDate } from "@/utils/datetime";
-import { convertedAmount } from "@/utils/numbers";
-import { addressShortner } from "@/utils/token";
-import { Order as CowOrder } from "@cowprotocol/cow-sdk";
+import {
+  cowExplorerUrl,
+  orderPairSymbolsText,
+  StackOrder,
+  StackOrderProps,
+} from "@/models";
+import { useNetworkContext } from "@/contexts";
 
 const INITIAL_NUMBER_OF_COW_ORDERS = 8;
 const MORE_ORDERS_NUMBER = 4;
@@ -86,7 +90,7 @@ const TableCowBody = ({
   stackOrder: StackOrder;
   cowOrders: CowOrder[];
 }) => {
-  const chainId = 100; // @todo use context or useNetwork hook
+  const { chainId } = useNetworkContext();
 
   return (
     <TableBody>

--- a/packages/app/components/stack-modal/StackOrdersTable.tsx
+++ b/packages/app/components/stack-modal/StackOrdersTable.tsx
@@ -138,7 +138,7 @@ const TableCowBody = ({
                 </BodyText>
               ) : (
                 <BodyText className="text-gray-400 animate-pulse" size={1}>
-                  fulfilling
+                  in progress
                 </BodyText>
               )}
             </TableCell>

--- a/packages/app/components/stack-modal/StackOrdersTable.tsx
+++ b/packages/app/components/stack-modal/StackOrdersTable.tsx
@@ -87,62 +87,64 @@ const TableCowBody = ({
   cowOrders: CowOrder[];
 }) => {
   const chainId = 100; // @todo use context or useNetwork hook
-  const averagePrice = (cowOrder: CowOrder) =>
-    (
-      Number(cowOrder.executedSellAmount) / Number(cowOrder.executedBuyAmount)
-    ).toFixed(4);
 
   return (
     <TableBody>
-      {cowOrders.map((cowOrder) => (
-        <TableRow key={cowOrder.uid}>
-          <TableCell className="py-2 md:table-cell">
-            <BodyText
-              size={1}
-              className="text-primary-700 hover:underline hover:underline-offset-2"
-            >
-              <Link
-                target="_blank"
-                href={cowExplorerUrl(chainId, cowOrder.uid)}
+      {cowOrders.map((cowOrder) => {
+        const executedBuyAmount = convertedAmount(
+          cowOrder.executedBuyAmount,
+          stackOrder.buyToken.decimals
+        );
+        const executedSellAmount = convertedAmount(
+          cowOrder.executedSellAmount,
+          stackOrder.sellToken.decimals
+        );
+        const averagePrice = executedSellAmount / executedBuyAmount;
+
+        return (
+          <TableRow key={cowOrder.uid}>
+            <TableCell className="py-2 md:table-cell">
+              <BodyText
+                size={1}
+                className="text-primary-700 hover:underline hover:underline-offset-2"
               >
-                {addressShortner(cowOrder.uid)}
-              </Link>
-            </BodyText>
-          </TableCell>
-          <TableCell className="py-2">
-            <BodyText className="text-em-med" size={1}>
-              {formatDate(cowOrder.creationDate)}
-            </BodyText>
-          </TableCell>
-          <TableCell className="py-2 text-right ">
-            <BodyText className="text-em-med" size={1}>
-              {convertedAmount(
-                cowOrder.executedSellAmount,
-                stackOrder.sellToken.decimals
-              ).toFixed(4)}
-            </BodyText>
-          </TableCell>
-          <TableCell className="py-2 text-right ">
-            <BodyText className="text-em-med" size={1}>
-              {convertedAmount(
-                cowOrder.executedBuyAmount,
-                stackOrder.buyToken.decimals
-              ).toFixed(4)}
-            </BodyText>
-          </TableCell>
-          <TableCell className="hidden py-2 text-right md:table-cell">
-            {cowOrder.status === "fulfilled" ? (
+                <Link
+                  target="_blank"
+                  href={cowExplorerUrl(chainId, cowOrder.uid)}
+                >
+                  {addressShortner(cowOrder.uid)}
+                </Link>
+              </BodyText>
+            </TableCell>
+            <TableCell className="py-2">
               <BodyText className="text-em-med" size={1}>
-                {averagePrice(cowOrder)}
+                {formatDate(cowOrder.creationDate)}
               </BodyText>
-            ) : (
-              <BodyText className="text-gray-400 animate-pulse" size={1}>
-                fulfilling
+            </TableCell>
+            <TableCell className="py-2 text-right ">
+              <BodyText className="text-em-med" size={1}>
+                {executedSellAmount.toFixed(4)}
               </BodyText>
-            )}
-          </TableCell>
-        </TableRow>
-      ))}
+            </TableCell>
+            <TableCell className="py-2 text-right ">
+              <BodyText className="text-em-med" size={1}>
+                {executedBuyAmount.toFixed(4)}
+              </BodyText>
+            </TableCell>
+            <TableCell className="hidden py-2 text-right md:table-cell">
+              {cowOrder.status === "fulfilled" ? (
+                <BodyText className="text-em-med" size={1}>
+                  {averagePrice.toFixed(4)}
+                </BodyText>
+              ) : (
+                <BodyText className="text-gray-400 animate-pulse" size={1}>
+                  fulfilling
+                </BodyText>
+              )}
+            </TableCell>
+          </TableRow>
+        );
+      })}
     </TableBody>
   );
 };


### PR DESCRIPTION
## Fixes: [STK-216](https://linear.app/swaprhq/issue/STK-216/wrong-bought-token-price-on-orders-table)

# Description
* Update the way we compute the executed order AVG price

# Visual evidence
![image](https://github.com/SwaprHQ/stackly-ui/assets/21271189/a2d063cf-5aff-4284-b5a1-fdbd85f38cc0)



# How to test the changes
**PRE-CONDITIONS:** You need to have existing stacks with executed orders in place to test this fix

1) Pull this branch
2) Run the project locally
3) Go to Stackly dApp
4) Connect your wallet
5) Go to "Your Stacks", choose one of them, and click "View Details"
6) When the Order Details modal opens up, the right-most column should have the correct token pair price