### PR TITLE
Fixes: Switching network not working properly

### DIFF
--- a/packages/app/app/stacks/page.tsx
+++ b/packages/app/app/stacks/page.tsx
@@ -1,19 +1,20 @@
 "use client";
 
 import { StackOrders } from "@/app/stacks/stacksOrders";
-import { useAccount, useNetwork } from "wagmi";
+import { useAccount } from "wagmi";
 import NoWalletState from "./no-wallet-state";
+import { useNetworkContext } from "@/contexts";
 
 export default function Page() {
-  const { chain } = useNetwork();
+  const { chainId } = useNetworkContext();
   const { address, isDisconnected } = useAccount();
 
   if (isDisconnected) return <NoWalletState />;
 
   return (
     <div className="space-y-8">
-      {chain && address ? (
-        <StackOrders chainId={chain.id} address={address} />
+      {chainId && address ? (
+        <StackOrders chainId={chainId} address={address} />
       ) : (
         <Loading />
       )}

--- a/packages/app/app/stacks/stacksOrders.tsx
+++ b/packages/app/app/stacks/stacksOrders.tsx
@@ -47,9 +47,8 @@ export const StackOrders = ({ chainId, address }: StackOrdersProps) => {
   const fetchStacks = useCallback(() => {
     getOrders(chainId, address.toLowerCase())
       .then(async (orders) => {
-        if (!orders || orders.length === 0) {
-          setCurrentStackOrders([]);
-        } else {
+        if (!orders || orders.length === 0) setCurrentStackOrders([]);
+        else {
           const stackOrders = await getStackOrders(chainId, orders);
           if (stackOrders.length > 0) setCurrentStackOrders(stackOrders);
         }

--- a/packages/app/app/stacks/stacksOrders.tsx
+++ b/packages/app/app/stacks/stacksOrders.tsx
@@ -47,10 +47,12 @@ export const StackOrders = ({ chainId, address }: StackOrdersProps) => {
   const fetchStacks = useCallback(() => {
     getOrders(chainId, address.toLowerCase())
       .then(async (orders) => {
-        if (!orders || orders.length === 0) return;
-
-        const stackOrders = await getStackOrders(chainId, orders);
-        if (stackOrders.length > 0) setCurrentStackOrders(stackOrders);
+        if (!orders || orders.length === 0) {
+          setCurrentStackOrders([]);
+        } else {
+          const stackOrders = await getStackOrders(chainId, orders);
+          if (stackOrders.length > 0) setCurrentStackOrders(stackOrders);
+        }
       })
       .finally(() => setLoading(false));
   }, [address, chainId]);

--- a/packages/app/components/ConnectButton.tsx
+++ b/packages/app/components/ConnectButton.tsx
@@ -3,7 +3,7 @@
 import { ChainId, WETH, WXDAI } from "@stackly/sdk";
 import { ConnectKitButton } from "connectkit";
 import Image from "next/image";
-import { useAccount, useBalance, useEnsAvatar } from "wagmi";
+import { useBalance, useEnsAvatar } from "wagmi";
 
 import { BodyText, Button, SizeProps } from "@/ui";
 import { useAutoConnect } from "@/hooks";
@@ -21,7 +21,6 @@ const CustomConnectButton = ({
   size: SizeProps;
 }) => {
   const { selectedChain } = useNetworkContext();
-  const { isConnected } = useAccount();
   const { data: avatar } = useEnsAvatar({
     name: ensName,
     chainId: ChainId.ETHEREUM,
@@ -34,10 +33,7 @@ const CustomConnectButton = ({
 
   const { data: balance } = useBalance({
     address: address,
-    token:
-      selectedChain && isConnected
-        ? (TOKEN_BY_CHAIN[selectedChain.id] as `0x${string}`)
-        : (TOKEN_BY_CHAIN[ChainId.GNOSIS] as `0x${string}`),
+    token: TOKEN_BY_CHAIN[selectedChain.id] as `0x${string}`,
   });
 
   const truncatedAddress = (size: number) =>

--- a/packages/app/components/SelectNetwork.tsx
+++ b/packages/app/components/SelectNetwork.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Fragment } from "react";
-
 import { ChainIcon } from "connectkit";
 import { Listbox, Transition } from "@headlessui/react";
 
@@ -14,9 +13,9 @@ export const SelectNetwork = () => {
 
   return (
     <Listbox
-      value={selectedChain?.id.toString()}
+      value={selectedChain.id.toString()}
       onChange={(chainId) => {
-        changeNetwork(chainId);
+        changeNetwork(parseInt(chainId));
         resetFormValues(parseInt(chainId));
       }}
     >

--- a/packages/app/components/stack-modal/StackModal.tsx
+++ b/packages/app/components/stack-modal/StackModal.tsx
@@ -45,10 +45,9 @@ import {
 } from "@/components";
 import { StackProgress } from "@/components/stack-modal/StackProgress";
 import { StackOrdersTable } from "@/components/stack-modal/StackOrdersTable";
-import { ModalId, useModalContext } from "@/contexts";
+import { ModalId, useModalContext, useNetworkContext } from "@/contexts";
 import { TransactionLink } from "./TransactionLink";
 import { Transaction } from "@/models/stack";
-import { useNetwork } from "wagmi";
 
 interface StackModalProps extends ModalBaseProps {
   stackOrder: StackOrder;
@@ -71,7 +70,7 @@ export const StackModal = ({
   closeAction,
 }: StackModalProps) => {
   const signer = useEthersSigner();
-  const { chain } = useNetwork();
+  const { chainId } = useNetworkContext();
   const { closeModal, isModalOpen, openModal } = useModalContext();
 
   const [cancellationTx, setCancellationTx] = useState<Transaction>();
@@ -148,12 +147,12 @@ export const StackModal = ({
                 buyToken={stackOrder.buyToken}
                 sellToken={stackOrder.sellToken}
               />
-              {chain?.id && (
+              {chainId && (
                 <Link
                   passHref
                   target="_blank"
                   href={getExplorerLink(
-                    chain?.id,
+                    chainId,
                     stackOrder.id,
                     "address",
                     "#tokentxns"
@@ -256,8 +255,8 @@ export const StackModal = ({
         title={cancellationTx && "Proceeding cancellation"}
         description={cancellationTx && "Waiting for transaction confirmation."}
       >
-        {cancellationTx?.hash && chain?.id && (
-          <TransactionLink chainId={chain.id} hash={cancellationTx.hash} />
+        {cancellationTx?.hash && chainId && (
+          <TransactionLink chainId={chainId} hash={cancellationTx.hash} />
         )}
       </DialogConfirmTransactionLoading>
       <Dialog
@@ -269,8 +268,8 @@ export const StackModal = ({
           title="Stack Cancelled"
           description={`The ${stackRemainingFundsWithTokenText} were sent to your wallet.`}
         />
-        {cancellationTx?.hash && chain?.id && (
-          <TransactionLink chainId={chain.id} hash={cancellationTx.hash} />
+        {cancellationTx?.hash && chainId && (
+          <TransactionLink chainId={chainId} hash={cancellationTx.hash} />
         )}
         <DialogFooterActions
           primaryAction={() => {

--- a/packages/app/contexts/NetworkContext.tsx
+++ b/packages/app/contexts/NetworkContext.tsx
@@ -6,7 +6,6 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useMemo,
   useState,
 } from "react";
 import type { Chain } from "viem/chains";
@@ -17,7 +16,6 @@ import { useAccount, useNetwork, useSwitchNetwork } from "wagmi";
 import { config } from "@/providers/wagmi-config";
 import { useQueryState } from "next-usequerystate";
 import { checkIsValidChainId } from "@/utils";
-import { useChains, ChainIcon } from "connectkit";
 
 interface WagmiChain extends Chain {
   unsupported?: boolean;
@@ -53,25 +51,18 @@ export const NetworkContextProvider = ({
   const { chain } = useNetwork();
   const { isConnected } = useAccount();
 
+  const [, setFromTokenSearchParams] = useQueryState("fromToken");
+  const [, setToTokenSearchParams] = useQueryState("toToken");
   const [searchParamsChainId, setSearchParamsChainId] =
     useQueryState("chainId");
-  const [toTokenSearchParams, setToTokenSearchParams] =
-    useQueryState("toToken");
-  const [fromTokenSearchParams, setFromTokenSearchParams] =
-    useQueryState("fromToken");
 
   const [selectedChain, setSelectedChain] = useState<WagmiChain>(gnosis);
   const [selectedChainId, setSelectedChainId] = useState<ChainId>(gnosis.id);
 
-  const resetTokensSearchParams = useCallback(() => {
-    if (fromTokenSearchParams) setFromTokenSearchParams(null);
-    if (toTokenSearchParams) setToTokenSearchParams(null);
-  }, [
-    fromTokenSearchParams,
-    setFromTokenSearchParams,
-    setToTokenSearchParams,
-    toTokenSearchParams,
-  ]);
+  const resetTokensOnSearchParams = useCallback(() => {
+    setFromTokenSearchParams(null);
+    setToTokenSearchParams(null);
+  }, [setFromTokenSearchParams, setToTokenSearchParams]);
 
   const switchNetworkNotConnected = (newChainId: ChainId) => {
     config.setState((oldState: any) => {
@@ -96,39 +87,42 @@ export const NetworkContextProvider = ({
 
   const { switchNetwork } = useSwitchNetwork({
     onSuccess(data) {
-      resetTokensSearchParams();
       setSearchParamsChainId(data?.id.toString());
     },
   });
 
   useEffect(() => {
-    if (isConnected && chains) {
-      if (searchParamsChainId && switchNetwork) {
-        const isValidSearchParamsChainId = checkIsValidChainId(
-          parseInt(searchParamsChainId)
-        );
+    const parsedSearchParamsChainId = searchParamsChainId
+      ? parseInt(searchParamsChainId)
+      : 0;
+    const newChainIsDiferentFromCurrent =
+      parsedSearchParamsChainId !== chain?.id;
 
-        if (
-          isValidSearchParamsChainId &&
-          parseInt(searchParamsChainId) !== chain?.id
-        )
-          switchNetwork(parseInt(searchParamsChainId));
+    const isValidSearchParamsChainId = checkIsValidChainId(
+      parsedSearchParamsChainId
+    );
+
+    if (isValidSearchParamsChainId) {
+      if (isConnected && switchNetwork && newChainIsDiferentFromCurrent) {
+        switchNetwork(parsedSearchParamsChainId);
+        return;
       }
-    } else {
-      if (searchParamsChainId) {
-        const chainFromSearchParams = chains?.find(
-          (chain: any) => chain.id === parseInt(searchParamsChainId)
+
+      if (chains) {
+        const chainFromSearchParams = chains.find(
+          (chain) => chain.id === parsedSearchParamsChainId
         );
 
         if (chainFromSearchParams) {
-          switchNetworkNotConnected(chainFromSearchParams.id);
+          setSelectedChain(chainFromSearchParams);
+          setSelectedChainId(chainFromSearchParams.id);
+          return;
         }
-      } else {
-        // set default chain
-        setSelectedChain(gnosis);
-        setSelectedChainId(gnosis.id);
       }
     }
+    // set default chain
+    setSelectedChain(gnosis);
+    setSelectedChainId(gnosis.id);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isConnected, chains, searchParamsChainId, switchNetwork]);
@@ -140,10 +134,12 @@ export const NetworkContextProvider = ({
     }
   }, [chain, isConnected]);
   const changeNetwork = (networkId: ChainId) => {
+    resetTokensOnSearchParams();
     isConnected
       ? switchNetwork && switchNetwork(networkId)
       : switchNetworkNotConnected(networkId);
   };
+
   const networkContext = {
     chains,
     chainId: selectedChainId,

--- a/packages/app/contexts/NetworkContext.tsx
+++ b/packages/app/contexts/NetworkContext.tsx
@@ -14,7 +14,7 @@ import { gnosis } from "wagmi/chains";
 import { useAccount, useNetwork, useSwitchNetwork } from "wagmi";
 
 import { config } from "@/providers/wagmi-config";
-import { parseAsInteger, useQueryState } from "next-usequerystate";
+import { useQueryState } from "next-usequerystate";
 import { checkIsValidChainId } from "@/utils";
 
 interface WagmiChain extends Chain {
@@ -27,10 +27,10 @@ const throwNetworkContextError = () => {
 
 interface NetworkContextProps {
   chains?: WagmiChain[];
-  chainId?: ChainId;
+  chainId: ChainId;
   changeNetwork: (newChainId: number) => void;
   selectedChain: WagmiChain;
-  setChainId: React.Dispatch<React.SetStateAction<ChainId | undefined>>;
+  setChainId: React.Dispatch<React.SetStateAction<ChainId>>;
 }
 
 const NetworkContext = createContext<NetworkContextProps>({
@@ -55,7 +55,7 @@ export const NetworkContextProvider = ({
   const { chains } = config.getPublicClient();
 
   const [selectedChain, setSelectedChain] = useState<WagmiChain>(gnosis);
-  const [selectedChainId, setSelectedChainId] = useState<ChainId>();
+  const [selectedChainId, setSelectedChainId] = useState<ChainId>(gnosis.id);
 
   const { switchNetwork } = useSwitchNetwork({
     onSuccess(data) {

--- a/packages/app/contexts/StackboxFormContext.tsx
+++ b/packages/app/contexts/StackboxFormContext.tsx
@@ -11,7 +11,7 @@ import {
   useQueryState,
 } from "next-usequerystate";
 
-import { DEFAULT_TOKENS_BY_CHAIN, getIsValidChainId } from "@/utils";
+import { DEFAULT_TOKENS_BY_CHAIN, checkIsValidChainId } from "@/utils";
 import { FREQUENCY_OPTIONS } from "@/models/stack";
 import {
   TokenWithBalance,
@@ -72,7 +72,9 @@ export const StackboxFormContextProvider = ({
   const { getTokenFromList } = useTokenListContext();
 
   const getDefaultParsedToken = (tokenDirection: "to" | "from") => {
-    const validChainId = getIsValidChainId(chainId) ? chainId : ChainId.GNOSIS;
+    const validChainId = checkIsValidChainId(chainId)
+      ? chainId
+      : ChainId.GNOSIS;
 
     return createParser({
       parse: (address: string) => getTokenFromList(address),
@@ -109,7 +111,7 @@ export const StackboxFormContextProvider = ({
 
   const stackboxFormContext = useMemo(() => {
     const resetFormValues = (newChainId: ChainId) => {
-      const validChainId = getIsValidChainId(newChainId)
+      const validChainId = checkIsValidChainId(newChainId)
         ? newChainId
         : ChainId.GNOSIS;
 

--- a/packages/app/contexts/TokenListContext.tsx
+++ b/packages/app/contexts/TokenListContext.tsx
@@ -174,7 +174,6 @@ export const TokenListProvider = ({ children }: PropsWithChildren) => {
     setupTokenList();
 
     return () => {
-      // Cleanup: Abort ongoing fetch when component unmounts or chainId changes
       abortControllerRef.current.abort();
       abortControllerRef.current = new AbortController();
     };

--- a/packages/app/providers/Providers.tsx
+++ b/packages/app/providers/Providers.tsx
@@ -17,7 +17,7 @@ import {
 export const Providers = ({ children }: PropsWithChildren) => {
   return (
     <WagmiConfig config={config}>
-      <ConnectKitProvider mode="light">
+      <ConnectKitProvider mode="light" options={{ initialChainId: 0 }}>
         <NetworkContextProvider>
           <TokenListProvider>
             <ModalContextProvider>

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "target": "es5",
+    "downlevelIteration": true,
     "lib": [
       "dom",
       "dom.iterable",

--- a/packages/app/utils/chain.ts
+++ b/packages/app/utils/chain.ts
@@ -1,4 +1,4 @@
 import { ChainId } from "@stackly/sdk";
 
-export const getIsValidChainId = (newChainId: number): Boolean =>
+export const checkIsValidChainId = (newChainId: number): Boolean =>
   Object.values(ChainId).some((chainId) => chainId === newChainId);


### PR DESCRIPTION
This PR was mainly refactoring NetworkProvider to fixe this issue: Trying to switch to Ethereum network not working.

https://gyazo.com/c1139b2d7775f7866004f86835016575

This breaks using Stackly on Safe wallet, cause on safe to access wallets is on network base. So to access on ethereum mainnet, you can't switch to gnosis and then back to Ethereum.
