### PR TITLE
feat: sort stacks by start/end time

### DIFF
--- a/packages/app/app/stacks/stacksOrders.tsx
+++ b/packages/app/app/stacks/stacksOrders.tsx
@@ -27,20 +27,34 @@ export const StackOrders = ({ chainId, address }: StackOrdersProps) => {
     []
   );
 
-  const ordersByType = [
+  type SortTime = "startTime" | "endTime" | "cancelledAt";
+
+  interface OrderByType {
+    orders: StackOrder[];
+    emptyText: string;
+    sort: SortTime;
+  }
+
+  const ordersByType: OrderByType[] = [
     {
       orders: filterActiveOrders(currentStackOrders),
       emptyText: "No active stacks",
+      sort: "startTime",
     },
     {
       orders: filterCompletedOrders(currentStackOrders),
       emptyText: "No complete stacks",
+      sort: "endTime",
     },
     {
       orders: filterCancelledOrders(currentStackOrders),
       emptyText: "No cancelled stacks",
+      sort: "cancelledAt",
     },
   ];
+
+  const sortedOrdersByTime = (orders: StackOrder[], time: SortTime) =>
+    orders.sort((a, b) => Number(b[time]) - Number(a[time]));
 
   const fetchStacks = useCallback(() => {
     getOrders(chainId, address.toLowerCase())
@@ -90,7 +104,10 @@ export const StackOrders = ({ chainId, address }: StackOrdersProps) => {
                   <Tab.Panel key={stacks.emptyText}>
                     {stacks.orders.length ? (
                       <StacksTable
-                        stackOrders={stacks.orders}
+                        stackOrders={sortedOrdersByTime(
+                          stacks.orders,
+                          stacks.sort
+                        )}
                         refetchStacks={fetchStacks}
                       />
                     ) : (


### PR DESCRIPTION
**Problem**
Looking into orders they are disorganised and it's hard to check on the past orders.

### Cancelled orders
**Previously**
<img width="1083" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/c18e9c69-e34b-4061-8814-fc79acdef2e8">

**Now**
<img width="1086" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/9b1b2c48-6b88-4b8d-aefe-d38e611ba376">


### Completed orders
**Previously**
<img width="1168" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/7cd5c419-3f5b-4b11-9507-539679bdbef1">
**Now**
<img width="1156" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/e3e5fc6a-c053-4aa1-9cba-54b006ba8b51">
