### PR TITLE
add rETH to our default token list

### DIFF
--- a/packages/app/public/assets/blockchains/ethereum/tokenlist.json
+++ b/packages/app/public/assets/blockchains/ethereum/tokenlist.json
@@ -86,5 +86,13 @@
     "decimals": 6,
     "logoURI": "/assets/images/tokens/usdc.png",
     "chainId": 1
+  },
+  {
+    "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+    "name": "Rocket Pool ETH",
+    "symbol": "rETH",
+    "decimals": 18,
+    "logoURI": "/assets/images/tokens/reth.png",
+    "chainId": 1
   }
 ]


### PR DESCRIPTION
**Problem**
we have rETH on our common tokens so we have to make sure we have an image.

<img width="407" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/439a9e22-db84-4af5-be47-36332e243614">

**Solution**
Add it to our tokenlist.json so we have control of image and data.

<img width="645" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/8b1d72cb-e9c4-4d53-88e3-ee3173d929da">
