### PR TITLE
When token amount is 0 should not show stack summary

### DIFF
--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -464,7 +464,7 @@ export const Stackbox = () => {
             </div>
             <div className="space-y-1">
               <div className="flex flex-col border divide-y md:divide-y-0 md:flex-row rounded-2xl border-surface-50 md:divide-x divide-surface-50">
-                <div className="flex flex-col w-full pl-4 pr-3 py-2 lg:py-3 space-y-2 hover:bg-surface-25">
+                <div className="flex flex-col w-full py-2 pl-4 pr-3 space-y-2 lg:py-3 hover:bg-surface-25">
                   <BodyText size={2}>Starting from</BodyText>
                   <DatePicker
                     dateTime={startDateTime}
@@ -506,7 +506,7 @@ export const Stackbox = () => {
             </div>
           </div>
         </div>
-        {fromToken && toToken && tokenAmount && tokenAmount > "0" && (
+        {fromToken && toToken && tokenAmount && parseFloat(tokenAmount) > 0 && (
           <div
             className={cx(
               "p-2 text-center bg-surface-25 text-em-low rounded-xl",


### PR DESCRIPTION
Should parseFloat token amount instead of comparing with a string.

**Problem**
<img width="583" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/7b479348-04bf-4c03-88e6-c24a3bff5bbb">

**with parseFloat**
<img width="834" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/bbf9178c-c1f5-4c52-b64a-727646b51572">
