### PR TITLE
Add estimated total stack

### DIFF
--- a/packages/app/components/stack-modal/StackProgress.tsx
+++ b/packages/app/components/stack-modal/StackProgress.tsx
@@ -52,7 +52,7 @@ const TotalStackEstimationText = ({ stackOrder }: StackOrderProps) => {
           </span>
           <span>{stackOrder.buyToken.symbol}</span>
         </BodyText>
-        <TokenIcon size="xs" token={stackOrder.buyToken} />
+        <TokenIcon size="2xs" token={stackOrder.buyToken} />
       </div>
     </div>
   );

--- a/packages/app/components/stack-modal/StackProgress.tsx
+++ b/packages/app/components/stack-modal/StackProgress.tsx
@@ -43,7 +43,7 @@ const TotalStackEstimationText = ({ stackOrder }: StackOrderProps) => {
     <div className="flex flex-row-reverse">
       <div
         className="flex items-center space-x-1"
-        title="An estimation of the total tokens you'll buy based on the average price."
+        title="An estimation of the total tokens you'll buy based on the average price (calc: amount / avg)."
       >
         <BodyText size={1} className="space-x-1">
           <span className="text-em-low">Estimated total:</span>

--- a/packages/app/components/stack-modal/StackProgress.tsx
+++ b/packages/app/components/stack-modal/StackProgress.tsx
@@ -1,4 +1,5 @@
 import {
+  allOrderSlotsDone,
   totalFundsAmountWithTokenText,
   totalOrderSlotsDone,
 } from "@/models/order";
@@ -9,6 +10,7 @@ import {
   StackOrderProps,
   totalStackOrdersDone,
   totalFundsUsed,
+  estimatedTotalStack,
 } from "@/models/stack-order";
 import { formatTokenValue } from "@/utils/token";
 
@@ -29,8 +31,28 @@ export const StackProgress = ({ stackOrder }: StackOrderProps) => (
       </div>
     </div>
     <OrdersProgressBar stackOrder={stackOrder} />
+    <TotalStackEstimationText stackOrder={stackOrder} />
   </div>
 );
+
+const TotalStackEstimationText = ({ stackOrder }: StackOrderProps) => {
+  if (allOrderSlotsDone(stackOrder)) return;
+  if (totalStackOrdersDone(stackOrder) < 1) return;
+
+  return (
+    <div className="flex flex-row-reverse">
+      <div className="flex items-center space-x-1">
+        <BodyText size="responsive" className="space-x-1">
+          <span className="text-em-low">Estimated total stack:</span>
+          <span className="text-em-med">
+            {formatTokenValue(estimatedTotalStack(stackOrder))}
+          </span>
+        </BodyText>
+        <TokenIcon size="xs" token={stackOrder.buyToken} />
+      </div>
+    </div>
+  );
+};
 
 const OrdersExecuted = ({ stackOrder }: StackOrderProps) => {
   if (!totalOrderSlotsDone(stackOrder))

--- a/packages/app/components/stack-modal/StackProgress.tsx
+++ b/packages/app/components/stack-modal/StackProgress.tsx
@@ -41,12 +41,16 @@ const TotalStackEstimationText = ({ stackOrder }: StackOrderProps) => {
 
   return (
     <div className="flex flex-row-reverse">
-      <div className="flex items-center space-x-1">
-        <BodyText size="responsive" className="space-x-1">
-          <span className="text-em-low">Estimated total stack:</span>
+      <div
+        className="flex items-center space-x-1"
+        title="An estimation of the total tokens you'll buy based on the average price."
+      >
+        <BodyText size={1} className="space-x-1">
+          <span className="text-em-low">Estimated total:</span>
           <span className="text-em-med">
             {formatTokenValue(estimatedTotalStack(stackOrder))}
           </span>
+          <span>{stackOrder.buyToken.symbol}</span>
         </BodyText>
         <TokenIcon size="xs" token={stackOrder.buyToken} />
       </div>

--- a/packages/app/models/stack-order/stack-order.ts
+++ b/packages/app/models/stack-order/stack-order.ts
@@ -10,12 +10,12 @@ export const totalStackOrdersDone = (order: StackOrder) => {
 };
 
 export const estimatedTotalStack = (order: StackOrder) => {
-  const avgStackPrice = calculateStackAveragePrice(order);
   let estimation = 0;
+  const avgStackPrice = calculateStackAveragePrice(order);
 
   if (order.cowOrders && order.cowOrders.length > 0) {
     estimation =
-      convertedAmount(order.amount, order.buyToken.decimals) / avgStackPrice;
+      convertedAmount(order.amount, order.sellToken.decimals) / avgStackPrice;
   }
 
   return estimation;

--- a/packages/app/models/stack-order/stack-order.ts
+++ b/packages/app/models/stack-order/stack-order.ts
@@ -9,6 +9,18 @@ export const totalStackOrdersDone = (order: StackOrder) => {
   return order.cowOrders.length;
 };
 
+export const estimatedTotalStack = (order: StackOrder) => {
+  const avgStackPrice = calculateStackAveragePrice(order);
+  let estimation = 0;
+
+  if (order.cowOrders && order.cowOrders.length > 0) {
+    estimation =
+      convertedAmount(order.amount, order.buyToken.decimals) / avgStackPrice;
+  }
+
+  return estimation;
+};
+
 export const calculateStackAveragePrice = (order: StackOrder) => {
   let totalExecutedBuyAmount = 0;
   let totalExecutedSellAmount = 0;


### PR DESCRIPTION
Show estimated total stack when we do first order.

estimation function is:
`Stack amount / avg stack price`

Don't show when no orders or stack is complete.

preview:
<img width="1427" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/f270c5f8-6cbc-4965-a8b4-1c16afb0f9de">
