### PR TITLE
fix: missing token name and symbol on subgraph

### DIFF
--- a/packages/subgraph/src/mappings/order.ts
+++ b/packages/subgraph/src/mappings/order.ts
@@ -19,8 +19,19 @@ export function createOrReturnTokenEntity(contractAddress: Address): Token {
   let tokenContract = ERC20Contract.bind(contractAddress);
   token = new Token(contractAddress.toHex());
   token.address = contractAddress;
-  token.name = tokenContract.name();
-  token.symbol = tokenContract.symbol();
+
+  token.name = "";
+  let tryName = tokenContract.try_name();
+  if (!tryName.reverted) {
+    token.name = tryName.value;
+  }
+
+  token.symbol = "";
+  let trySymbol = tokenContract.try_symbol();
+  if (!trySymbol.reverted) {
+    token.symbol = trySymbol.value;
+  }
+
   token.decimals = tokenContract.decimals();
   token.save();
   return token;


### PR DESCRIPTION
Sometimes token name or symbol are missing from contract. This fix prevents that to break the subgraph and UI.