### PR TITLE
fix: improve token names

### DIFF
--- a/packages/app/public/assets/blockchains/arbitrum/tokenlist.json
+++ b/packages/app/public/assets/blockchains/arbitrum/tokenlist.json
@@ -1,8 +1,7 @@
 [
-
   {
     "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
-    "name": "Wrapped Ether on Arbitrum network",
+    "name": "Wrapped Ether",
     "symbol": "WETH",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/weth.png",
@@ -10,7 +9,7 @@
   },
   {
     "address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
-    "name": "Dai Stablecoin on Arbitrum network",
+    "name": "Dai Stablecoin",
     "symbol": "DAI",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/dai.png",
@@ -18,7 +17,7 @@
   },
   {
     "address": "0x912CE59144191C1204E64559FE8253a0e49E6548",
-    "name": "Arb Token on Arbitrum network",
+    "name": "Arbitrum",
     "symbol": "ARB",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/arb.png",
@@ -26,7 +25,7 @@
   },
   {
     "address": "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
-    "name": "Wrapped BTC on Arbitrum network",
+    "name": "Wrapped BTC",
     "symbol": "WBTC",
     "decimals": 8,
     "logoURI": "/assets/images/tokens/wbtc.png",
@@ -34,7 +33,7 @@
   },
   {
     "address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
-    "name": "USDC on Arbitrum network",
+    "name": "USD Coin",
     "symbol": "USDC",
     "decimals": 6,
     "logoURI": "/assets/images/tokens/usdc.png",
@@ -42,7 +41,7 @@
   },
   {
     "address": "0xdE903E2712288A1dA82942DDdF2c20529565aC30",
-    "name": "Swapr on Arbitrum network",
+    "name": "Swapr",
     "symbol": "SWPR",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/swapr.png",
@@ -50,14 +49,10 @@
   },
   {
     "address": "0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8",
-    "name": "Balancer on Arbitrum network",
+    "name": "Balancer",
     "symbol": "BAL",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/balancer.png",
     "chainId": 42161
   }
 ]
-
-
-
-

--- a/packages/app/public/assets/blockchains/ethereum/tokenlist.json
+++ b/packages/app/public/assets/blockchains/ethereum/tokenlist.json
@@ -1,7 +1,7 @@
 [
   {
     "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-    "name": "Wrapped Ether on Ethereum mainnet",
+    "name": "Wrapped Ether",
     "symbol": "WETH",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/weth.png",
@@ -9,7 +9,7 @@
   },
   {
     "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-    "name": "Dai Stablecoin on Ethereum mainnet",
+    "name": "Dai Stablecoin",
     "symbol": "DAI",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/dai.png",
@@ -17,7 +17,7 @@
   },
   {
     "address": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
-    "name": "Gnosis Token on Ethereum mainnet",
+    "name": "Gnosis",
     "symbol": "GNO",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/gno.png",
@@ -25,7 +25,7 @@
   },
   {
     "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
-    "name": "Aave Token on Ethereum mainnet",
+    "name": "Aave Token",
     "symbol": "AAVE",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/aave.png",
@@ -33,7 +33,7 @@
   },
   {
     "address": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
-    "name": "Matic Token on Ethereum mainnet",
+    "name": "Matic Token",
     "symbol": "MATIC",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/matic.png",
@@ -41,7 +41,7 @@
   },
   {
     "address": "0x111111111117dC0aa78b770fA6A738034120C302",
-    "name": "1INCH Token on Ethereum mainnet",
+    "name": "1INCH Token",
     "symbol": "1INCH",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/1inch.png",
@@ -49,7 +49,7 @@
   },
   {
     "address": "0xba100000625a3754423978a60c9317c58a424e3D",
-    "name": "Balancer on Ethereum mainnet",
+    "name": "Balancer",
     "symbol": "BAL",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/balancer.png",
@@ -57,7 +57,7 @@
   },
   {
     "address": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
-    "name": "CoW Protocol Token on Ethereum mainnet",
+    "name": "CoW Protocol Token",
     "symbol": "COW",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/cow.png",
@@ -65,7 +65,7 @@
   },
   {
     "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
-    "name": "Wrapped BTC on Ethereum mainnet",
+    "name": "Wrapped BTC",
     "symbol": "WBTC",
     "decimals": 8,
     "logoURI": "/assets/images/tokens/wbtc.png",
@@ -73,7 +73,7 @@
   },
   {
     "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-    "name": "USDC on Ethereum mainnet",
+    "name": "USDC",
     "symbol": "USDC",
     "decimals": 6,
     "logoURI": "/assets/images/tokens/usdc.png",
@@ -89,7 +89,7 @@
   },
   {
     "address": "0x6cAcDB97e3fC8136805a9E7c342d866ab77D0957",
-    "name": "Swapr on Ethereum mainnet",
+    "name": "Swapr",
     "symbol": "SWPR",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/swapr.png",

--- a/packages/app/public/assets/blockchains/gnosis/tokenlist.json
+++ b/packages/app/public/assets/blockchains/gnosis/tokenlist.json
@@ -1,7 +1,7 @@
 [
   {
     "address": "0x532801ED6f82FFfD2DAB70A19fC2d7B2772C4f4b",
-    "name": "Swapr on Gnosis chain",
+    "name": "Swapr on xDai",
     "symbol": "SWPR",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/swapr.png",
@@ -9,7 +9,7 @@
   },
   {
     "address": "0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1",
-    "name": "Wrapped Ether on Gnosis chain",
+    "name": "Wrapped Ether on xDai",
     "symbol": "WETH",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/weth.png",
@@ -25,7 +25,7 @@
   },
   {
     "address": "0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb",
-    "name": "Gnosis Token on Gnosis chain",
+    "name": "Gnosis Token on xDai",
     "symbol": "GNO",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/gno.png",
@@ -33,7 +33,7 @@
   },
   {
     "address": "0xDF613aF6B44a31299E48131e9347F034347E2F00",
-    "name": "Aave Token on Gnosis chain",
+    "name": "Aave Token on xDai",
     "symbol": "AAVE",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/aave.png",
@@ -41,7 +41,7 @@
   },
   {
     "address": "0x7122d7661c4564b7C6Cd4878B06766489a6028A2",
-    "name": "Matic Token on Gnosis chain",
+    "name": "Matic Token on xDai",
     "symbol": "MATIC",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/matic.png",
@@ -49,7 +49,7 @@
   },
   {
     "address": "0x7f7440C5098462f833E123B44B8A03E1d9785BAb",
-    "name": "1INCH Token on Gnosis chain",
+    "name": "1INCH Token on xDai",
     "symbol": "1INCH",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/1inch.png",
@@ -57,7 +57,7 @@
   },
   {
     "address": "0x7eF541E2a22058048904fE5744f9c7E4C57AF717",
-    "name": "Balancer on Gnosis chain",
+    "name": "Balancer on xDai",
     "symbol": "BAL",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/balancer.png",
@@ -65,7 +65,7 @@
   },
   {
     "address": "0x177127622c4A00F3d409B75571e12cB3c8973d3c",
-    "name": "CoW Protocol Token on Gnosis chain",
+    "name": "CoW Protocol Token from Mainnet",
     "symbol": "COW",
     "decimals": 18,
     "logoURI": "/assets/images/tokens/cow.png",
@@ -73,7 +73,7 @@
   },
   {
     "address": "0x8e5bBbb09Ed1ebdE8674Cda39A0c169401db4252",
-    "name": "Wrapped BTC on Gnosis",
+    "name": "Wrapped BTC on xDai",
     "symbol": "WBTC",
     "decimals": 8,
     "logoURI": "/assets/images/tokens/wbtc.png",
@@ -81,7 +81,7 @@
   },
   {
     "address": "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83",
-    "name": "USD//C on Gnosis",
+    "name": "USD//C on xDai",
     "symbol": "USDC",
     "decimals": 6,
     "logoURI": "/assets/images/tokens/usdc.png",


### PR DESCRIPTION
Improve token names to mirror what is defined on chain, so users can be confident on the token they are trading.