### PR TITLE
show complete bar on orders when all funds are used

### DIFF
--- a/packages/app/components/OrdersProgressBar.tsx
+++ b/packages/app/components/OrdersProgressBar.tsx
@@ -3,14 +3,16 @@ import React, { useRef, useEffect } from "react";
 
 export const OrdersProgressBar = ({ stackOrder }: StackOrderProps) => {
   const progressBarRef = useRef<HTMLDivElement>(null);
+  const totalOrders = totalStackOrdersDone(stackOrder)
+    ? totalStackOrdersDone(stackOrder)
+    : stackOrder.orderSlots.length;
 
   useEffect(() => {
     if (progressBarRef.current) {
-      const width =
-        (100 * totalStackOrdersDone(stackOrder)) / stackOrder.orderSlots.length;
+      const width = (100 * totalStackOrdersDone(stackOrder)) / totalOrders;
       progressBarRef.current.style.width = `${width}%`;
     }
-  }, [stackOrder]);
+  }, [stackOrder, totalOrders]);
 
   return (
     <div className="w-full h-2 rounded-lg bg-surface-75">

--- a/packages/app/components/StacksTable.tsx
+++ b/packages/app/components/StacksTable.tsx
@@ -69,7 +69,7 @@ export const StacksTable = ({
             <TableHead>Stack</TableHead>
             <TableHead className="text-right">Used funds</TableHead>
             <TableHead className="text-right">Avg. Buy Price</TableHead>
-            <TableHead className="text-right">Progress</TableHead>
+            <TableHead className="text-right">Orders</TableHead>
             <TableHead className="text-right"></TableHead>
           </TableRow>
         </TableHeader>

--- a/packages/app/components/stack-modal/StackProgress.tsx
+++ b/packages/app/components/stack-modal/StackProgress.tsx
@@ -11,6 +11,7 @@ import {
   totalStackOrdersDone,
   totalFundsUsed,
   estimatedTotalStack,
+  stackIsComplete,
 } from "@/models/stack-order";
 import { formatTokenValue } from "@/utils/token";
 
@@ -69,7 +70,12 @@ const OrdersExecuted = ({ stackOrder }: StackOrderProps) => {
       </BodyText>
       <BodyText size="responsive">
         {totalStackOrdersDone(stackOrder)}{" "}
-        <span className="text-xs">out of</span> {stackOrder.orderSlots.length}
+        {!stackIsComplete(stackOrder) && (
+          <>
+            <span className="text-xs">out of </span>
+            {stackOrder.orderSlots.length}
+          </>
+        )}
       </BodyText>
     </div>
   );


### PR DESCRIPTION
**before**
<img width="733" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/eeab3d3b-7a31-4e76-81b8-37f4fb850ac2">

**after**
- Show only orders that were executed 
- show full bar
<img width="726" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/18ee287a-37f4-4935-b356-f5e3a7cc0cab">
