### PR TITLE
Simplify confirm stack

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,15 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🧑🏻‍💻 Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 🥷 Setup node and bun
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
+        with:
+          node-version: 21.1.0
       - uses: oven-sh/setup-bun@v1
         with:
-          node-version: lts/hydrogen
-          check-latest: true
-
+          bun-version: latest
       - name: 🎪 Install dependencies
         run: bun install --immutable
 

--- a/packages/app/components/stack-modal/StackFrequencyAndDates.tsx
+++ b/packages/app/components/stack-modal/StackFrequencyAndDates.tsx
@@ -1,0 +1,54 @@
+import {
+  StackOrderProps,
+  stackIsComplete,
+  stackIsFinishedWithFunds,
+  totalOrderSlotsDone,
+} from "@/models";
+import { BodyText } from "@/ui";
+import { formatFrequencyHours, formatTimestampToDateWithTime } from "@/utils";
+import { ReactNode } from "react";
+
+const StackDetail = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) => (
+  <div className="space-y-1">
+    <BodyText size={1} className="text-em-low">
+      {title}
+    </BodyText>
+    <BodyText size={1}>{children}</BodyText>
+  </div>
+);
+
+export const StackFrequencyAndDates = ({ stackOrder }: StackOrderProps) => {
+  const orderSlots = stackOrder.orderSlots;
+  const firstSlot = orderSlots[0];
+  const lastSlot = orderSlots[orderSlots.length - 1];
+  const nextSlot = orderSlots[totalOrderSlotsDone(stackOrder)];
+
+  return (
+    <div className="grid grid-cols-2 gap-5 px-4 md:px-6 gap-x-8 md:grid-cols-4">
+      <StackDetail title="Starts on">
+        {formatTimestampToDateWithTime(firstSlot)}
+      </StackDetail>
+      <StackDetail title="Ends on">
+        {formatTimestampToDateWithTime(lastSlot)}
+      </StackDetail>
+      <StackDetail title="Frequency">
+        Every {formatFrequencyHours(Number(stackOrder.interval))}
+      </StackDetail>
+      <StackDetail title="Next order">
+        {stackIsComplete(stackOrder)
+          ? "Complete"
+          : stackIsFinishedWithFunds(stackOrder)
+          ? "Finished with funds"
+          : stackOrder.cancelledAt
+          ? "Cancelled"
+          : formatTimestampToDateWithTime(nextSlot)}
+      </StackDetail>
+    </div>
+  );
+};

--- a/packages/app/components/stack-modal/StackModal.tsx
+++ b/packages/app/components/stack-modal/StackModal.tsx
@@ -212,11 +212,11 @@ export const StackModal = ({
             </div>
           )}
           <div className="px-4 space-y-4 md:px-6">
+            <StackDigest stackOrder={stackOrder} />
             <TitleText size={2} weight="bold">
               Orders
             </TitleText>
             <StackProgress stackOrder={stackOrder} />
-            <StackInfo stackOrder={stackOrder} />
             {totalStackOrdersDone(stackOrder) > 0 && (
               <StackOrdersTable stackOrder={stackOrder} />
             )}
@@ -289,7 +289,7 @@ export const StackModal = ({
   );
 };
 
-const StackInfo = ({ stackOrder }: StackOrderProps) => (
+const StackDigest = ({ stackOrder }: StackOrderProps) => (
   <div className="flex flex-col justify-between gap-2 px-4 py-3 md:px-6 md:items-center md:flex-row bg-surface-25 rounded-2xl">
     <FromToStackTokenPair
       fromToken={stackOrder.sellToken}

--- a/packages/app/components/stack-modal/StackOrdersProgress.tsx
+++ b/packages/app/components/stack-modal/StackOrdersProgress.tsx
@@ -4,7 +4,7 @@ import {
   totalOrderSlotsDone,
 } from "@/models/order";
 import { OrdersProgressBar } from "@/components/OrdersProgressBar";
-import { BodyText } from "@/ui";
+import { BodyText, TitleText } from "@/ui";
 import { TokenIcon } from "@/components/TokenIcon";
 import {
   StackOrderProps,
@@ -14,26 +14,37 @@ import {
   stackIsComplete,
 } from "@/models/stack-order";
 import { formatTokenValue } from "@/utils/token";
+import { StackOrdersTable } from "@/components/stack-modal/StackOrdersTable";
 
-export const StackProgress = ({ stackOrder }: StackOrderProps) => (
-  <div className="space-y-2">
-    <div className="flex flex-col justify-between space-y-1 md:space-y-0 md:items-center md:flex-row">
-      <OrdersExecuted stackOrder={stackOrder} />
-      <div className="flex items-center space-x-1">
-        <BodyText size="responsive" className="text-em-low">
-          Total funds used:{" "}
-          <span className="text-em-high">
-            {formatTokenValue(totalFundsUsed(stackOrder), 2)}{" "}
-            <span className="text-xs">of</span>{" "}
-            {totalFundsAmountWithTokenText(stackOrder)}
-          </span>
-        </BodyText>
-        <TokenIcon size="xs" token={stackOrder.sellToken} />
+export const StackOrdersProgress = ({ stackOrder }: StackOrderProps) => (
+  <>
+    <div>
+      <TitleText size={2} weight="bold" className="mb-2">
+        Orders
+      </TitleText>
+      <div className="space-y-2">
+        <div className="flex flex-col justify-between space-y-1 md:space-y-0 md:items-center md:flex-row">
+          <OrdersExecuted stackOrder={stackOrder} />
+          <div className="flex items-center space-x-1">
+            <BodyText size="responsive" className="text-em-low">
+              Total funds used:{" "}
+              <span className="text-em-high">
+                {formatTokenValue(totalFundsUsed(stackOrder), 2)}{" "}
+                <span className="text-xs">of</span>{" "}
+                {totalFundsAmountWithTokenText(stackOrder)}
+              </span>
+            </BodyText>
+            <TokenIcon size="xs" token={stackOrder.sellToken} />
+          </div>
+        </div>
+        <OrdersProgressBar stackOrder={stackOrder} />
+        <TotalStackEstimationText stackOrder={stackOrder} />
       </div>
     </div>
-    <OrdersProgressBar stackOrder={stackOrder} />
-    <TotalStackEstimationText stackOrder={stackOrder} />
-  </div>
+    {totalStackOrdersDone(stackOrder) > 0 && (
+      <StackOrdersTable stackOrder={stackOrder} />
+    )}
+  </>
 );
 
 const TotalStackEstimationText = ({ stackOrder }: StackOrderProps) => {

--- a/packages/app/components/stack-modal/StackOrdersTable.tsx
+++ b/packages/app/components/stack-modal/StackOrdersTable.tsx
@@ -44,7 +44,10 @@ export const StackOrdersTable = ({ stackOrder }: StackOrderProps) => {
         <TableHeader>
           <TableRow>
             <TableHead className="py-1 md:table-cell">
-              <BodyText size={1}>Transaction</BodyText>
+              <BodyText size={1}>
+                <span className="hidden md:inline-block">Transaction</span>
+                <span className="md:hidden">Tx</span>
+              </BodyText>
             </TableHead>
             <TableHead>
               <BodyText size={1}>Time</BodyText>
@@ -127,7 +130,12 @@ const TableCowBody = ({
                   target="_blank"
                   href={cowExplorerUrl(chainId, cowOrder.uid)}
                 >
-                  {addressShortner(cowOrder.uid)}
+                  <span className="md:hidden">
+                    {addressShortner(cowOrder.uid, 2)}
+                  </span>
+                  <span className="hidden md:inline-block">
+                    {addressShortner(cowOrder.uid)}
+                  </span>
                 </Link>
               </BodyText>
             </TableCell>

--- a/packages/app/components/stackbox/ConfirmStackModal.tsx
+++ b/packages/app/components/stackbox/ConfirmStackModal.tsx
@@ -207,7 +207,10 @@ export const ConfirmStackModal = ({
               <span className="text-em-high">
                 {amountPerOrder} {fromToken.symbol}
               </span>
-              , every {FREQUENCY_OPTIONS[frequency]}
+              <br />
+              <span className="text-em-high">
+                every {FREQUENCY_OPTIONS[frequency]}
+              </span>
             </TitleText>
           </div>
           <div className="w-full p-5 space-y-2 bg-surface-25 rounded-xl">
@@ -220,15 +223,13 @@ export const ConfirmStackModal = ({
               <BodyText>{format(endTime, "dd MMM yy, HH:mm")}</BodyText>
             </div>
             <div className="flex items-center justify-between">
-              <BodyText className="text-em-med">
-                Total funds to be used
-              </BodyText>
+              <BodyText className="text-em-med">Total funds</BodyText>
               <BodyText className="text-end">
                 {amount} {fromToken.symbol}
               </BodyText>
             </div>
             <div className="flex items-center justify-between">
-              <BodyText className="text-em-med">Stack fee</BodyText>
+              <BodyText className="text-em-med">Fee</BodyText>
               <BodyText>0.25%</BodyText>
             </div>
           </div>

--- a/packages/app/utils/token.ts
+++ b/packages/app/utils/token.ts
@@ -1,5 +1,5 @@
-export const addressShortner = (address: string) =>
-  address.slice(0, 4) + "..." + address.slice(-4);
+export const addressShortner = (address: string, elements: number = 4) =>
+  address.slice(0, elements) + "..." + address.slice(-elements);
 
 export const formatTokenValue = (
   value: number | string,


### PR DESCRIPTION
**Summary** 
- Simplify text on Confirm Modal
- Refactor StackModal code
- Simplify orders table column on mobile

**Problem**
<img width="488" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/45ee470a-d0da-4966-bd89-e123d9d9b2ce">
<img width="454" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/950762e9-d947-42fe-b9b0-997a0f46de90">


**Now**
<img width="720" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/42f22aea-79d3-45cb-9a3a-ded1005f03e1">
<img width="760" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/50646023-2755-4c2e-8617-e55cec291865">




Also orders table on mobile now show "tx" and less numbers on the address.
<img width="494" alt="image" src="https://github.com/SwaprHQ/stackly-ui/assets/5664434/5e5f6dc1-dcdf-4583-9dd3-afd6a6dd119c">



