### PR TITLE
[STK-233][FIX] -  Bug in UI order amount calcs

### DIFF
--- a/packages/app/components/stackbox/ConfirmStackModal.tsx
+++ b/packages/app/components/stackbox/ConfirmStackModal.tsx
@@ -87,11 +87,9 @@ export const ConfirmStackModal = ({
   const [stackCreationTx, setStackCreationTx] = useState<Transaction>();
 
   const rawAmount = parseUnits(amount, fromToken.decimals);
-  const estimatedNumberOfOrders =
-    Math.floor(
-      (endTime.getTime() - startTime.getTime()) / frequencySeconds[frequency]
-    ) + INITAL_ORDER;
-
+  const estimatedNumberOfOrders = Math.floor(
+    (endTime.getTime() - startTime.getTime()) / frequencySeconds[frequency]
+  );
   const amountPerOrder = (parseFloat(amount) / estimatedNumberOfOrders).toFixed(
     2
   );


### PR DESCRIPTION
## Fixes: [STK-233](https://linear.app/swaprhq/issue/STK-233/bug-in-ui-order-amount-calcs)

## Context
After @berteotti investigation on the SC side, he found out that we were not executing a trade on the end date, so we were displaying different computation values in the UI and the SC.

## Description
* Removes the `INITIAL_ORDER` value (= `1`) from the `estimatedNumberOfOrders` calculation to mimic the current logic in the Smart Contract side.

