### PR TITLE
[STK-255][FIX] - My Stacks breaks for some one time orders

### DIFF
--- a/packages/app/components/StacksTable.tsx
+++ b/packages/app/components/StacksTable.tsx
@@ -195,12 +195,14 @@ const OrdersProgressText = ({ stackOrder }: StackOrderProps) => {
         <BodyText className="text-em-high">
           {totalStackOrdersDone(stackOrder).toString()}
         </BodyText>
-        <BodyText className="text-em-low">{`/ ${stackOrder.orderSlots.length} orders`}</BodyText>
+        <BodyText className="text-em-low">{`/ ${
+          stackOrder.orderSlots.length || stackOrder.cowOrders.length
+        } orders`}</BodyText>
       </>
     );
   }
 
-  const firtTimeSlot = Number(stackOrder.orderSlots[0]);
+  const firtTimeSlot = Number(stackOrder.orderSlots[0] ?? stackOrder.startTime);
   const date = new Date(firtTimeSlot * 1000); // Convert seconds to milliseconds
   const distanceToNow = formatDistanceToNow(date, { addSuffix: true });
 

--- a/packages/app/components/stack-modal/StackFrequencyAndDates.tsx
+++ b/packages/app/components/stack-modal/StackFrequencyAndDates.tsx
@@ -25,8 +25,11 @@ const StackDetail = ({
 
 export const StackFrequencyAndDates = ({ stackOrder }: StackOrderProps) => {
   const orderSlots = stackOrder.orderSlots;
-  const firstSlot = orderSlots[0];
-  const lastSlot = orderSlots[orderSlots.length - 1];
+  const hasSlots = Boolean(orderSlots.length);
+  const firstSlot = hasSlots ? orderSlots[0] : stackOrder.startTime;
+  const lastSlot = hasSlots
+    ? orderSlots[orderSlots.length - 1]
+    : stackOrder.endTime;
   const nextSlot = orderSlots[totalOrderSlotsDone(stackOrder)];
 
   return (

--- a/packages/app/models/order/order.ts
+++ b/packages/app/models/order/order.ts
@@ -18,8 +18,12 @@ export const totalOrderSlotsDone = (order: Order) => {
   }, 0);
 };
 
-export const allOrderSlotsDone = (order: Order) =>
-  totalOrderSlotsDone(order) === order.orderSlots.length;
+export const allOrderSlotsDone = (order: Order) => {
+  const orderSlotsLength = order.orderSlots.length;
+  if (!orderSlotsLength) return totalOrderSlotsDone(order) === 1;
+
+  return totalOrderSlotsDone(order) === orderSlotsLength;
+};
 
 export const totalFundsAmount = (order: Order) => {
   const total =

--- a/packages/app/models/order/order.ts
+++ b/packages/app/models/order/order.ts
@@ -3,6 +3,15 @@ import { currentTimestampInSeconds } from "@/utils/datetime";
 import { Order } from "@stackly/sdk";
 
 export const totalOrderSlotsDone = (order: Order) => {
+  /**
+   * An order that doesn't have slots happens when we have a 1 slot order
+   * that has start and end date in a timeframe equals to or less than 60'.
+   * As it's not possible to use the slot timestamp, we use the start time
+   * for this 1-time order.
+   */
+  if (!order.orderSlots.length)
+    return order.startTime < currentTimestampInSeconds ? 1 : 0;
+
   return order.orderSlots.reduce((count, orderTimestamp) => {
     if (Number(orderTimestamp) < currentTimestampInSeconds) return ++count;
     return count;

--- a/packages/app/models/order/order.ts
+++ b/packages/app/models/order/order.ts
@@ -5,9 +5,9 @@ import { Order } from "@stackly/sdk";
 export const totalOrderSlotsDone = (order: Order) => {
   /**
    * An order that doesn't have slots happens when we have a 1 slot order
-   * that has start and end date in a timeframe equals to or less than 60'.
+   * that has start and end date in a timeframe equal or less than 60'.
    * As it's not possible to use the slot timestamp, we use the start time
-   * for this 1-time order.
+   * for this 1 slot order.
    */
   if (!order.orderSlots.length)
     return order.startTime < currentTimestampInSeconds ? 1 : 0;


### PR DESCRIPTION
## Fixes: 
* [STK-255](https://linear.app/swaprhq/issue/STK-255/my-stacks-breaks-for-some-one-time-orders)
* [STK-257](https://linear.app/swaprhq/issue/STK-257/order-details-display-wrong-start-and-end-dates)

## Description
* Adds different checks when we have a stack with no `orderSlots`.

## Visual Evidence
https://www.loom.com/share/6522431e773f4350af5ce0b70c93f909?sid=1fd75bc2-f862-4aa8-bf96-61e762dc12f5
