### PR TITLE
[STK-249][FIX] - Stackbox start date fails TX creation

### DIFF
--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -105,7 +105,7 @@ export const Stackbox = () => {
 
   const [showTokenAmountError, setShowTokenAmountError] = useState(false);
   const [showPastEndDateError, setShowPastEndDateError] = useState(false);
-  const [isPastStartDate, setIsPastStartDate] = useState(false);
+  const [isNearStartDate, setIsNearStartDate] = useState(false);
   const [showFromTokenError, setShowFromTokenError] = useState(false);
   const [showToTokenError, setShowToTokenError] = useState(false);
   const [showInsufficentBalanceError, setShowInsufficentBalanceError] =
@@ -199,11 +199,11 @@ export const Stackbox = () => {
     const startDate = startDateTime.getTime();
     const endDate = endDateTime.getTime();
     const isEndTimeBeforeStartTime = endDate <= startDate;
-    const isStartTimeInThePast = startDate <= Date.now();
+    const isStartTimeNearNow = startDate <= getDateNowPlus10Mins();
     const isTokenAmountZero = tokenAmount === "0";
 
     setShowPastEndDateError(isEndTimeBeforeStartTime);
-    setIsPastStartDate(isStartTimeInThePast);
+    setIsNearStartDate(isStartTimeNearNow);
 
     if (!fromToken || !toToken) {
       if (!fromToken) setShowFromTokenError(true);
@@ -585,7 +585,7 @@ export const Stackbox = () => {
           amount={tokenAmount}
           frequency={frequency}
           startTime={
-            isPastStartDate ? new Date(getDateNowPlus10Mins()) : startDateTime
+            isNearStartDate ? new Date(getDateNowPlus10Mins()) : startDateTime
           }
           endTime={endDateTime}
           isOpen={isModalOpen(ModalId.CONFIRM_STACK)}


### PR DESCRIPTION
## Fixes: [STK-249](https://linear.app/swaprhq/issue/STK-249/stackbox-start-date-fails-tx-creation)

## Description
* Updates the start time on the stack confirmation modal if the start time is equal to or less than 10 minutes in the future.

## Visual Evidence
https://www.loom.com/share/434fe59f8a3a4019874864c2c29fb64b?sid=2731eb81-3b8e-4acd-8865-c5bd6ffcaa88
