### PR TITLE
[STK-253][FIX] - My Stacks displaying NaN

### DIFF
--- a/packages/app/components/stack-modal/StackFrequencyAndDates.tsx
+++ b/packages/app/components/stack-modal/StackFrequencyAndDates.tsx
@@ -50,7 +50,7 @@ export const StackFrequencyAndDates = ({ stackOrder }: StackOrderProps) => {
           ? "Finished with funds"
           : stackOrder.cancelledAt
           ? "Cancelled"
-          : formatTimestampToDateWithTime(nextSlot)}
+          : formatTimestampToDateWithTime(hasSlots ? nextSlot : firstSlot)}
       </StackDetail>
     </div>
   );

--- a/packages/app/models/stack-order/stack-order.ts
+++ b/packages/app/models/stack-order/stack-order.ts
@@ -41,7 +41,7 @@ export const calculateStackAveragePrice = (order: StackOrder) => {
     );
   });
   const averagePrice = totalExecutedSellAmount / totalExecutedBuyAmount;
-  return averagePrice;
+  return totalExecutedBuyAmount ? averagePrice : 0;
 };
 
 export const totalFundsUsed = (order: StackOrder) => {


### PR DESCRIPTION
## Fixes: [STK-253](https://linear.app/swaprhq/issue/STK-253/my-stacks-displaying-nan)

## Description
* Uses the "Start Date" to compute the "Next Order" date for no-slots stacks.
* Returns 0 if there's no executed buy amount for an order (this may happen if the order expires, for example)
