### PR TITLE
[STK-247][FIX] - Network switching bug

### DIFF
--- a/packages/app/contexts/TokenListContext.tsx
+++ b/packages/app/contexts/TokenListContext.tsx
@@ -69,8 +69,11 @@ const TokenListContext = createContext<{
 });
 
 export const TokenListProvider = ({ children }: PropsWithChildren) => {
-  const { address } = useAccount();
-  const { chainId } = useNetworkContext();
+  const { address, chainId: wagmiChainId, isConnected } = useAccount();
+  const { chainId: contextChainId } = useNetworkContext();
+  const chainId = isConnected
+    ? wagmiChainId ?? ChainId.ARBITRUM
+    : contextChainId;
   const abortControllerRef = useRef(new AbortController());
 
   const [tokenList, setTokenList] = useState<TokenFromTokenlist[]>(


### PR DESCRIPTION
## Fixes: [STK-247](https://linear.app/swaprhq/issue/STK-247/network-switching-bug)

## Context
Long story short: I couldn't find why some of our context chainId changes do not trigger the effect that fetches the balances for a connected wallet. The chainId value changes correctly, but this doesn't trigger the effect sometimes.

Some of the reasons for a value change in the effect dependency array not triggering the effect execution:
* React makes a shallow comparison on values, meaning, if the value reference in memory does not change, then it won't trigger the effect (for example mutating an array or an object)
* Values outside the React state sometimes do not trigger effects

So, all-in-all, values present in the dependency array do not guarantee the effect to trigger when these change. If there are other reasons for this to happen (most likely there are) I couldn't find them.

I propose this solution because it's simple and seems to fix the issue, but please check it and speak out your opinion because I'm not 100% convinced about it. As far as I could check, this happens just for token balances fetch. I also tried aborting ongoing fetch values (with the Abort Controller pattern) and a bunch of other stuff with no success.

## Description
* Uses different chain ID sources if a wallet is connected or not

## Visual Evidence
https://www.loom.com/share/d49d6b37a5d2463ea1222dce3308780d?sid=e43f11f9-587e-4f86-b0da-0a92924afb6e