### PR TITLE
[STK-215][FIX] - Completed stack with funds without showing "withdraw" button

### DIFF
--- a/packages/app/models/stack-order/stack-order.ts
+++ b/packages/app/models/stack-order/stack-order.ts
@@ -64,13 +64,16 @@ export const totalStacked = (order: StackOrder) =>
   }, 0) ?? 0;
 
 export const stackHasRemainingFunds = (stackOrder: StackOrder) =>
-  totalFundsUsed(stackOrder) > stacklyFee(stackOrder) &&
+  totalFundsUsed(stackOrder) >= stacklyFee(stackOrder) &&
   stackRemainingFunds(stackOrder) > stacklyFee(stackOrder);
 
 export const stackRemainingFunds = (stackOrder: StackOrder) => {
-  if (totalFundsUsed(stackOrder) === 0 && totalStackOrdersDone(stackOrder) > 0)
+  if (
+    stackOrder.cowOrders.length &&
+    totalFundsUsed(stackOrder) === 0 &&
+    totalStackOrdersDone(stackOrder) > 0
+  )
     return 0;
-
   return (
     convertedAmount(stackOrder.amount, stackOrder.sellToken.decimals) -
     totalFundsUsed(stackOrder)


### PR DESCRIPTION
## Fixes: [STK-215](https://linear.app/swaprhq/issue/STK-215/fix-completed-stack-with-funds-without-showing-withdraw-button)

## Description
* Updates our checks for stack remaining funds, we had an edge-case bug where if the stack only spent our protocol fee and the stack completed without spending any more funds, we didn't allow the user to withdraw the remaining unspent funds.

## Visual Evidence
https://www.loom.com/share/0dbc2f9189104fa9a64e65bb2858927b?sid=fb70b53a-b4d4-4c43-868d-c0d31eb50047