### PR TITLE
[STK-258][FIX] - Bar showing complete on the first order 

### DIFF
--- a/packages/app/components/OrdersProgressBar.tsx
+++ b/packages/app/components/OrdersProgressBar.tsx
@@ -1,5 +1,11 @@
-import { StackOrderProps, totalStackOrdersDone } from "@/models/stack-order";
+import {
+  stackHasRemainingFunds,
+  StackOrderProps,
+  totalStackOrdersDone,
+} from "@/models/stack-order";
 import React, { useRef, useEffect } from "react";
+
+const FULL_BAR_WIDTH = 100;
 
 export const OrdersProgressBar = ({ stackOrder }: StackOrderProps) => {
   const progressBarRef = useRef<HTMLDivElement>(null);
@@ -9,7 +15,9 @@ export const OrdersProgressBar = ({ stackOrder }: StackOrderProps) => {
 
   useEffect(() => {
     if (progressBarRef.current) {
-      const width = (100 * totalStackOrdersDone(stackOrder)) / totalOrders;
+      const width = stackHasRemainingFunds(stackOrder)
+        ? (FULL_BAR_WIDTH * totalStackOrdersDone(stackOrder)) / totalOrders
+        : FULL_BAR_WIDTH;
       progressBarRef.current.style.width = `${width}%`;
     }
   }, [stackOrder, totalOrders]);

--- a/packages/app/components/OrdersProgressBar.tsx
+++ b/packages/app/components/OrdersProgressBar.tsx
@@ -3,9 +3,9 @@ import React, { useRef, useEffect } from "react";
 
 export const OrdersProgressBar = ({ stackOrder }: StackOrderProps) => {
   const progressBarRef = useRef<HTMLDivElement>(null);
-  const totalOrders = totalStackOrdersDone(stackOrder)
-    ? totalStackOrdersDone(stackOrder)
-    : stackOrder.orderSlots.length;
+  const totalOrders = stackOrder.orderSlots.length
+    ? stackOrder.orderSlots.length
+    : 1;
 
   useEffect(() => {
     if (progressBarRef.current) {

--- a/packages/app/models/stack-order/stack-order.ts
+++ b/packages/app/models/stack-order/stack-order.ts
@@ -63,7 +63,7 @@ export const totalStacked = (order: StackOrder) =>
     );
   }, 0) ?? 0;
 
-const stackHasRemainingFunds = (stackOrder: StackOrder) =>
+export const stackHasRemainingFunds = (stackOrder: StackOrder) =>
   totalFundsUsed(stackOrder) > stacklyFee(stackOrder) &&
   stackRemainingFunds(stackOrder) > stacklyFee(stackOrder);
 


### PR DESCRIPTION
## Fixes: [STK-258](https://linear.app/swaprhq/issue/STK-258/bar-showing-complete-on-the-first-order)

## Description
* Updates the computations we do to set the progress bar, we were taking the executed orders as the total orders.

## Visual Evidence
![Screenshot 2024-08-07 at 12 15 02](https://github.com/user-attachments/assets/c8d9d087-8e4c-455f-a1b8-1d7e12583253)
