### PR TITLE
[STK-217][FIX] - Input on mobile unable to use decimals

### DIFF
--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -372,7 +372,8 @@ export const Stackbox = () => {
           <input
             min={0}
             type="number"
-            pattern="[0-9]*"
+            pattern="\d*"
+            inputMode="decimal"
             placeholder="0.0"
             className={cx(
               "w-full py-3 text-4xl font-semibold outline-none text-em-med text-ellipsis",


### PR DESCRIPTION
 ## Fixes: [STK-217](https://linear.app/swaprhq/issue/STK-217/fix-input-on-mobile-unable-to-use-decimals)

## Description
* Updates amount input pattern and allows decimal values

## Visual Evidence
![image](https://github.com/user-attachments/assets/aa6f6599-74e9-4b9e-a5fe-ae073be2cc5e)
