### PR TITLE
[FIX][STK-252] - Update My Stack tabs after stack cancellation

### DIFF
--- a/packages/app/app/stacks/stacksOrders.tsx
+++ b/packages/app/app/stacks/stacksOrders.tsx
@@ -231,6 +231,7 @@ export const StackOrders = ({ chainId, address }: StackOrdersProps) => {
                           stacks.orders,
                           stacks.sort
                         )}
+                        refetchAllOrders={fetchAllOrders}
                         refetchStacks={() =>
                           fetchStacks(index as StackStateIndex)
                         }

--- a/packages/app/components/StacksTable.tsx
+++ b/packages/app/components/StacksTable.tsx
@@ -37,6 +37,7 @@ import { ModalId, useModalContext } from "@/contexts";
 
 interface StacksTableProps {
   stackOrders: StackOrder[];
+  refetchAllOrders: () => void;
   refetchStacks: () => void;
   hasMorePages: boolean;
   hasLessPages: boolean;
@@ -46,6 +47,7 @@ interface StacksTableProps {
 
 export const StacksTable = ({
   stackOrders,
+  refetchAllOrders,
   refetchStacks,
   hasMorePages,
   hasLessPages,
@@ -165,6 +167,7 @@ export const StacksTable = ({
       {stackOrder && (
         <StackModal
           refetchStacks={refetchStacks}
+          refetchAllOrders={refetchAllOrders}
           isOpen={isModalOpen(ModalId.STACK)}
           closeAction={() => closeModal(ModalId.STACK)}
           stackOrder={stackOrder}

--- a/packages/app/components/stack-modal/StackModal.tsx
+++ b/packages/app/components/stack-modal/StackModal.tsx
@@ -51,6 +51,7 @@ import { Transaction } from "@/models/stack";
 
 interface StackModalProps extends ModalBaseProps {
   stackOrder: StackOrder;
+  refetchAllOrders: () => void;
   refetchStacks: () => void;
 }
 
@@ -66,6 +67,7 @@ type Content = {
 export const StackModal = ({
   stackOrder,
   isOpen,
+  refetchAllOrders,
   refetchStacks,
   closeAction,
 }: StackModalProps) => {
@@ -245,6 +247,7 @@ export const StackModal = ({
         <DialogFooterActions
           primaryAction={() => {
             refetchStacks();
+            refetchAllOrders();
             closeModal(ModalId.CANCEL_STACK_PROCESSING);
             closeModal(ModalId.CANCEL_STACK_SUCCESS);
             closeAction();

--- a/packages/app/models/stack-order/stack-order.ts
+++ b/packages/app/models/stack-order/stack-order.ts
@@ -69,7 +69,7 @@ export const stackHasRemainingFunds = (stackOrder: StackOrder) =>
 
 export const stackRemainingFunds = (stackOrder: StackOrder) => {
   if (
-    stackOrder.cowOrders.length &&
+    stackOrder.cowOrders?.length &&
     totalFundsUsed(stackOrder) === 0 &&
     totalStackOrdersDone(stackOrder) > 0
   )


### PR DESCRIPTION
 ## Fixes: [STK-252](https://linear.app/swaprhq/issue/STK-252/update-my-stack-tabs)

## Description
* Adds an optional chaining for safety navigation inside `stack-order.ts` to cover an edge case where it might break the app on a fast tab switch, to get the remaining funds of the stack.
* Re-fetches all the user orders after successfully canceling a stack

## Visual Evidence
https://www.loom.com/share/3dbdab016ac840b09b77f8e63076ced0?sid=d5e43b35-a395-4e2b-b6ae-9f3c3288924f