### PR TITLE
[FIX][STK-259] -No image in Stackbox token icons

### DIFF
--- a/packages/app/components/SelectNetwork.tsx
+++ b/packages/app/components/SelectNetwork.tsx
@@ -19,7 +19,6 @@ export const SelectNetwork = () => {
       value={chainId.toString()}
       onChange={(chainId) => {
         changeNetwork(parseInt(chainId));
-        if (pathname === PATHNAMES.HOME) resetFormValues(parseInt(chainId));
       }}
     >
       <div className="relative">

--- a/packages/app/components/stackbox/Stackbox.tsx
+++ b/packages/app/components/stackbox/Stackbox.tsx
@@ -49,6 +49,7 @@ import {
   frequencySeconds,
 } from "@/models";
 import { PATHNAMES } from "@/constants";
+import { checkIsValidChainId } from "@/utils";
 
 interface SelectTokenButtonProps {
   label: string;
@@ -190,6 +191,13 @@ export const Stackbox = () => {
     tokenList,
     tokenListWithBalances,
   ]);
+
+  useEffect(() => {
+    const isValidChainId = checkIsValidChainId(chainId);
+
+    if (isValidChainId) resetFormValues(chainId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chainId]);
 
   const openTokenPicker = (isFromToken = true) => {
     setIsPickingFromToken(isFromToken);

--- a/packages/app/contexts/NetworkContext.tsx
+++ b/packages/app/contexts/NetworkContext.tsx
@@ -3,7 +3,6 @@
 import {
   ReactNode,
   createContext,
-  useCallback,
   useContext,
   useEffect,
   useState,
@@ -50,18 +49,11 @@ export const NetworkContextProvider = ({
   const { chains } = config;
   const { isConnected, chain } = useAccount();
 
-  const [, setFromTokenSearchParams] = useQueryState("fromToken");
-  const [, setToTokenSearchParams] = useQueryState("toToken");
   const [searchParamsChainId, setSearchParamsChainId] =
     useQueryState("chainId");
 
   const [selectedChain, setSelectedChain] = useState<WagmiChain>(arbitrum);
   const [selectedChainId, setSelectedChainId] = useState<ChainId>(arbitrum.id);
-
-  const resetTokensOnSearchParams = useCallback(() => {
-    setFromTokenSearchParams(null);
-    setToTokenSearchParams(null);
-  }, [setFromTokenSearchParams, setToTokenSearchParams]);
 
   const switchNetworkNotConnected = (newChainId: ChainId) => {
     config.setState((oldState: any) => {
@@ -138,7 +130,6 @@ export const NetworkContextProvider = ({
     }
   }, [chain, isConnected]);
   const changeNetwork = (networkId: ChainId) => {
-    resetTokensOnSearchParams();
     isConnected
       ? switchChain && switchChain({ chainId: networkId })
       : switchNetworkNotConnected(networkId);


### PR DESCRIPTION
 ## Fixes: [STK-259](https://linear.app/swaprhq/issue/STK-259/no-image-in-stackbox-token-icons)

## Description
* Removes an unneeded search param reset from our Network Context.
* Removes an unwanted search params chain ID reset that was colliding with WAGMI's chain ID

## Visual Evidence
![Screenshot 2024-10-30 at 12 51 19](https://github.com/user-attachments/assets/3377e84b-efd6-4c5d-87e5-addfa97e67a2)
