### PR TITLE
[FIX][STK-261] - App breaks when the CoW API fails to fetch Stacks data

### DIFF
--- a/packages/app/app/stacks/stacksOrders.tsx
+++ b/packages/app/app/stacks/stacksOrders.tsx
@@ -159,7 +159,8 @@ export const StackOrders = ({ chainId, address }: StackOrdersProps) => {
           if (!orders || orders.length === 0) setCurrentStackOrders([]);
           else {
             const stackOrders = await getStackOrders(chainId, orders);
-            if (stackOrders.length > 0) setCurrentStackOrders(stackOrders);
+
+            setCurrentStackOrders(stackOrders?.length ? stackOrders : []);
           }
         })
         .finally(() => setLoadingStacks(false));


### PR DESCRIPTION
* *NOTE:* As I couldn't reproduce the CoW API failure locally, I can't provide visual evidence for this fix, but I think it should cover the use case where the CoW API fails to get Stacks data

 ## Fixes: [STK-261](https://linear.app/swaprhq/issue/STK-261/app-breaks-undefined-length-stackremainingfunds)

## Description
* Adds a safety check to cover CoW API failing to get the stack orders
